### PR TITLE
Alertmanager: reject global mattermost_webhook_url_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@
 * [BUGFIX] Compactor: Fix spurious `bucket operation fail after retries` error logs emitted during partial block cleanup. #7749
 * [BUGFIX] Alertmanager: Fix panic in `validateAlertmanagerConfig` when receiver config traversal encounters nil interface values. #7751
 * [BUGFIX] Parquet Converter: Fix `auto_forget_delay` having no effect. The ring lifecycler was created without the auto-forget delegate, so unhealthy instances were never automatically removed from the ring. #7752
-* [BUGFIX] Alertmanager: Reject the global `mattermost_webhook_url_file` setting in per-tenant configs, consistent with every other global `*_file` setting.
+* [BUGFIX] Alertmanager: Reject the global `mattermost_webhook_url_file` setting in per-tenant configs, consistent with every other global `*_file` setting. #7768
 
 ## 1.21.1 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 * [BUGFIX] Compactor: Fix spurious `bucket operation fail after retries` error logs emitted during partial block cleanup. #7749
 * [BUGFIX] Alertmanager: Fix panic in `validateAlertmanagerConfig` when receiver config traversal encounters nil interface values. #7751
 * [BUGFIX] Parquet Converter: Fix `auto_forget_delay` having no effect. The ring lifecycler was created without the auto-forget delegate, so unhealthy instances were never automatically removed from the ring. #7752
+* [BUGFIX] Alertmanager: Reject the global `mattermost_webhook_url_file` setting in per-tenant configs, consistent with every other global `*_file` setting.
 
 ## 1.21.1 2026-06-04
 

--- a/pkg/alertmanager/api.go
+++ b/pkg/alertmanager/api.go
@@ -78,7 +78,7 @@ var (
 	errEmailAuthSecretFileNotAllowed            = errors.New("setting Email auth_secret_file and global smtp_auth_secret_file is not allowed")
 	errIncidentIOURLFileNotAllowed              = errors.New("setting IncidentIO url_file is not allowed")
 	errIncidentIOAlertSourceTokenFileNotAllowed = errors.New("setting IncidentIO alert_source_token_file is not allowed")
-	errMatterMostWebhookUrlFileNotAllowed       = errors.New("setting Mattermost webhook_url_file is not allowed")
+	errMatterMostWebhookUrlFileNotAllowed       = errors.New("setting Mattermost webhook_url_file and global mattermost_webhook_url_file is not allowed")
 	errWeChatAPISecretFileNotAllowed            = errors.New("setting Wechat api_secret_file and global wechat_api_secret_file is not allowed")
 )
 
@@ -490,6 +490,9 @@ func validateReceiverTLSConfig(cfg commoncfg.TLSConfig) error {
 // validateGlobalConfig validates the Global config and returns an error if it contains
 // settings not allowed by Cortex.
 func validateGlobalConfig(cfg config.GlobalConfig) error {
+	if cfg.MattermostWebhookURLFile != "" {
+		return errMatterMostWebhookUrlFileNotAllowed
+	}
 	if cfg.OpsGenieAPIKeyFile != "" {
 		return errOpsGenieAPIKeyFileNotAllowed
 	}

--- a/pkg/alertmanager/api_test.go
+++ b/pkg/alertmanager/api_test.go
@@ -1022,6 +1022,24 @@ alertmanager_config: |
 `,
 			err: errors.Wrap(errMatterMostWebhookUrlFileNotAllowed, "error validating Alertmanager config"),
 		}, {
+			// No mattermost receiver here on purpose. When one is present, upstream copies
+			// the global value into the receiver's webhook_url_file during unmarshal and the
+			// per-receiver check already catches it. Without one, nothing propagated and the
+			// global field went unvalidated.
+			name: "Should return error if global mattermost_webhook_url_file is set without a Mattermost receiver",
+			cfg: `
+alertmanager_config: |
+  global:
+    mattermost_webhook_url_file: /secret
+  receivers:
+    - name: default-receiver
+      webhook_configs:
+        - url: http://localhost
+  route:
+    receiver: 'default-receiver'
+`,
+			err: errors.Wrap(errMatterMostWebhookUrlFileNotAllowed, "error validating Alertmanager config"),
+		}, {
 			name: "Should return error if global wechat_api_secret_file is set",
 			cfg: `
 alertmanager_config: |
@@ -1357,6 +1375,12 @@ func TestValidateAlertmanagerConfig(t *testing.T) {
 				}},
 			},
 			expected: errTLSFileNotAllowed,
+		},
+		"GlobalConfig with mattermost_webhook_url_file": {
+			input: config.GlobalConfig{
+				MattermostWebhookURLFile: "/secrets",
+			},
+			expected: errMatterMostWebhookUrlFileNotAllowed,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does**: Adds `mattermost_webhook_url_file` to the global `*_file` checks in `validateGlobalConfig`, the only one of the eleven that was missing.

Not exploitable today. When a mattermost receiver is present, upstream copies the global value into the receiver's `WebhookURLFile` during unmarshal, which runs before validation, so the per-receiver check already rejected it. With no mattermost receiver the value was accepted but never read.

The coverage was accidental though, resting entirely on upstream doing that propagation in `UnmarshalYAML`. Validating the field directly means the guarantee no longer depends on upstream ordering.

Reuses the existing error and extends its message to name both settings, matching how the other dual-scope settings are reported.

Found while auditing every file-path field reachable from a tenant config; the other 42 are all rejected.

CHANGELOG entry needs a PR number.
