### PR TITLE
querier: fix active query tracker panic on UTF-8 continuation bytes (fixes #7729)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## master / unreleased
+* [BUGFIX] Querier: Fix a panic in the active query tracker's `trimStringByBytes` when a request field consists only of UTF-8 continuation bytes (e.g. an unvalidated `match[]`/`query` value), which caused the rune-boundary scan to underflow and crash the querier. #7729
 * [FEATURE] Engine: Add `-querier.selector-batch-size` and `-ruler.selector-batch-size` flags to configure series batching in the Thanos promQL engine. 0 disables batching. #7763
 * [CHANGE] Querier: Make query time range configurations per-tenant: `query_ingesters_within`, `query_store_after`, and `shuffle_sharding_ingesters_lookback_period`. Uses `model.Duration` instead of `time.Duration` to support serialization but has minimum unit of 1ms (nanoseconds/microseconds not supported). #7160
 * [CHANGE] Cache: Setting `-blocks-storage.bucket-store.metadata-cache.bucket-index-content-ttl` to 0 will disable the bucket-index cache. #7446

--- a/pkg/util/request_tracker/request_extractor.go
+++ b/pkg/util/request_tracker/request_extractor.go
@@ -83,7 +83,10 @@ func trimStringByBytes(str string, size int) string {
 	bytesStr := []byte(str)
 	trimIndex := len(bytesStr)
 	if size < len(bytesStr) {
-		for !utf8.RuneStart(bytesStr[size]) {
+		// Scan backwards to a rune boundary. Bound the scan at size > 0: if the
+		// string has no rune start (e.g. only UTF-8 continuation bytes) the loop
+		// must not underflow past zero, which would panic on bytesStr[-1].
+		for size > 0 && !utf8.RuneStart(bytesStr[size]) {
 			size--
 		}
 		trimIndex = size

--- a/pkg/util/request_tracker/request_tracker_test.go
+++ b/pkg/util/request_tracker/request_tracker_test.go
@@ -191,3 +191,20 @@ func TestRangedQueryExtractorMultiByteTruncation(t *testing.T) {
 		assert.True(t, utf8.Valid(entry), "entry should be valid UTF-8")
 	})
 }
+
+// TestTrimForJsonMarshalContinuationBytes reproduces cortexproject/cortex#7729:
+// when the string consists only of UTF-8 continuation bytes (0x80-0xBF) there is
+// no rune start to scan back to, so the backwards scan in trimStringByBytes
+// underflows past zero and panics with index out of range [-1]. The fix bounds
+// the scan at size > 0.
+func TestTrimForJsonMarshalContinuationBytes(t *testing.T) {
+	// 1200 continuation bytes (0x80) with a truncation size below the length.
+	continuation := strings.Repeat("\x80", 1200)
+
+	require.NotPanics(t, func() {
+		out := trimForJsonMarshal(continuation, 900)
+		// Result must always be valid UTF-8 (no partial runes).
+		assert.True(t, utf8.ValidString(out), "result should be valid UTF-8")
+		assert.LessOrEqual(t, len(out), len(continuation))
+	})
+}


### PR DESCRIPTION
## Summary

Fixes cortexproject/cortex#7729.

`trimStringByBytes` (pkg/util/request_tracker/request_extractor.go) scans backwards from the truncation point to find a UTF-8 rune start, but the loop had no lower bound. When a request field consists only of UTF-8 continuation bytes (0x80–0xBF) there is no rune start to land on, so `size` underflows past zero and `bytesStr[-1]` panics with `index out of range [-1]`. Since the active query tracker is enabled by default and the panic occurs on a goroutine without `recover()`, an attacker-supplied `match[]`/`query` value can crash the querier (crash-loop on repeat).

The fix bounds the scan with `size > 0`. When no rune start exists, the field is truncated to an empty string, which is safe and still produces valid JSON.

## Verification

- Added `TestTrimForJsonMarshalContinuationBytes` with 1200 continuation bytes (`\x80`) truncated to size 900.
- Confirmed RED before the fix: `runtime error: index out of range [-1]`.
- Confirmed GREEN after the fix; full `pkg/util/request_tracker` suite passes.
- `gofmt -l` clean on changed files.

```sh
go test ./pkg/util/request_tracker/ -run TestTrimForJsonMarshalContinuationBytes -count=1
go test ./pkg/util/request_tracker/ -count=1
```

This is the same class of panic #7640 addressed in `trimForJsonMarshalRecursive`; that PR added a `repeatSize <= 0` guard but did not touch the underflow inside `trimStringByBytes`, and its regression tests used only valid multi-byte UTF-8 (`世`) which always terminates the backwards scan at index 0.

Signed-off-by: ...