### PR TITLE
Use Homebrew to install cortextool in the getting-started guides

### DIFF
--- a/docs/getting-started/microservices.md
+++ b/docs/getting-started/microservices.md
@@ -34,7 +34,7 @@ This guide will help you run Cortex in microservices mode using Kubernetes (Kind
 
 ### Optional Tools
 
-- [cortextool](https://github.com/cortexproject/cortex-tools/) - For managing rules and alerts
+- [cortextool](https://github.com/cortexproject/cortex-tools/) - For managing rules and alerts (install with `brew install cortexproject/tap/cortextool`)
 - [jq](https://jqlang.github.io/jq/) - For parsing JSON responses
 
 ## Architecture
@@ -373,24 +373,18 @@ kubectl --namespace cortex port-forward svc/cortex-nginx 8080:80 &
 
 ### Install cortextool (if needed)
 
-**macOS:**
 ```sh
-wget https://github.com/cortexproject/cortex-tools/releases/download/v0.17.0/cortextool_0.17.0_mac-os_x86_64 -O cortextool
-chmod +x cortextool
-sudo mv cortextool /usr/local/bin/
+brew install cortexproject/tap/cortextool
 ```
 
-**Linux:**
-```sh
-wget https://github.com/cortexproject/cortex-tools/releases/download/v0.17.0/cortextool_0.17.0_linux_x86_64 -O cortextool
-chmod +x cortextool
-sudo mv cortextool /usr/local/bin/
-```
+Works on macOS and Linux (including WSL2), builds from source, takes about a minute.
 
 **Or use Docker:**
 ```sh
-alias cortextool="docker run --rm --network host -v $(pwd):/workspace -w /workspace quay.io/cortexproject/cortex-tools:v0.17.0"
+alias cortextool="docker run --rm --network host -v $(pwd):/workspace -w /workspace quay.io/cortexproject/cortex-tools:v0.21.1"
 ```
+
+The Docker alias needs `--network host` to reach the `kubectl port-forward` on your host, which only works on Linux. On macOS and Windows, install cortextool with Homebrew instead.
 
 ### Load Recording and Alerting Rules
 
@@ -594,6 +588,7 @@ Kind requires Docker to have enough resources:
 ### cortextool commands fail
 - Make sure port-forward is running: `kubectl --namespace cortex port-forward svc/cortex-nginx 8080:80 &`
 - Verify Cortex is responding: `curl http://localhost:8080/ready`
+- If you're using the Docker alias, note that `--network host` only works on Linux. Install cortextool with `brew install cortexproject/tap/cortextool` to run it directly against the port-forward on any platform.
 
 ## Clean Up
 

--- a/docs/getting-started/single-binary.md
+++ b/docs/getting-started/single-binary.md
@@ -32,7 +32,7 @@ This guide will help you get Cortex running in single-binary mode using Docker C
 
 ### Optional Tools
 
-- [cortextool](https://github.com/cortexproject/cortex-tools/) - For managing rules and alerts (we'll use Docker to run this)
+- [cortextool](https://github.com/cortexproject/cortex-tools/) - For managing rules and alerts (install with `brew install cortexproject/tap/cortextool`)
 
 ## Architecture
 
@@ -159,22 +159,27 @@ Cortex can evaluate PromQL recording rules and alerting rules, similar to Promet
 
 The repository includes example rules in `rules.yaml` and `alerts.yaml`.
 
-### Load Rules into Cortex
+### Install cortextool
 
-**For Linux users:**
 ```sh
-docker run --network host \
-  -v "$(pwd):/workspace" -w /workspace \
-  quay.io/cortexproject/cortex-tools:v0.17.0 \
-  rules sync rules.yaml alerts.yaml --id cortex --address http://localhost:9009
+brew install cortexproject/tap/cortextool
 ```
 
-**For macOS/Windows users:**
+Works on macOS and Linux (including WSL2), builds from source, takes about a minute.
+
+**Or use Docker:**
 ```sh
-docker run --network cortex-docs-getting-started_default \
-  -v "$(pwd):/workspace" -w /workspace \
-  quay.io/cortexproject/cortex-tools:v0.17.0 \
-  rules sync rules.yaml alerts.yaml --id cortex --address http://cortex:9009
+alias cortextool="docker run --rm --network getting-started_default \
+  -v $(pwd):/workspace -w /workspace \
+  quay.io/cortexproject/cortex-tools:v0.21.1"
+```
+
+With the Docker alias, use `--address http://cortex:9009` instead of `http://localhost:9009` below — the container reaches Cortex over the Compose network, not your host.
+
+### Load Rules into Cortex
+
+```sh
+cortextool rules sync rules.yaml alerts.yaml --id cortex --address http://localhost:9009
 ```
 
 **Note:** The `--id cortex` flag specifies the tenant ID. Cortex is multi-tenant, so rules are namespaced by tenant.
@@ -194,20 +199,8 @@ Cortex includes a multi-tenant Alertmanager that receives alerts from the ruler.
 
 ### Load Alertmanager Configuration
 
-**For Linux users:**
 ```sh
-docker run --network host \
-  -v "$(pwd):/workspace" -w /workspace \
-  quay.io/cortexproject/cortex-tools:v0.17.0 \
-  alertmanager load alertmanager-config.yaml --id cortex --address http://localhost:9009
-```
-
-**For macOS/Windows users:**
-```sh
-docker run --network cortex-docs-getting-started_default \
-  -v "$(pwd):/workspace" -w /workspace \
-  quay.io/cortexproject/cortex-tools:v0.17.0 \
-  alertmanager load alertmanager-config.yaml --id cortex --address http://cortex:9009
+cortextool alertmanager load alertmanager-config.yaml --id cortex --address http://localhost:9009
 ```
 
 ### View Alertmanager in Grafana
@@ -484,11 +477,10 @@ lsof -i :3000  # Grafana
 2. Check Cortex is receiving metrics: `curl "http://localhost:9009/prometheus/api/v1/query?query=up"`
 3. Check Grafana datasource: Settings → Data sources → Cortex → Test
 
-### cortextool fails on macOS/Windows
-The `--network host` flag doesn't work on macOS/Windows. Use the Docker network name instead:
-```sh
-docker run --network cortex-docs-getting-started_default ...
-```
+### cortextool cannot reach Cortex
+1. Check the binary is on your `PATH`: `cortextool version`
+2. Check Cortex is up: `docker compose ps` should show `cortex` as healthy
+3. If you're using the Docker alias instead of a host install, use `--address http://cortex:9009` — a container can't reach Cortex on your host's `localhost`
 
 ### Out of memory errors
 Increase Docker's memory limit to 4GB or more:


### PR DESCRIPTION
## What this PR does

The [`cortexproject/homebrew-tap`](https://github.com/cortexproject/homebrew-tap) tap now publishes `cortextool`, so the getting-started guides can install it with one command:

```sh
brew install cortexproject/tap/cortextool
```

No `brew tap` and no `brew trust` needed — `brew install` auto-installs the tap and auto-trusts a fully-qualified formula name.

Before this, the guides installed `cortextool` the hard way:

- **`microservices.md`** had per-OS `wget` + `chmod +x` + `sudo mv` blocks pinned to **v0.17.0** (current is v0.21.1). The macOS block downloaded `cortextool_0.17.0_mac-os_x86_64` even on Apple Silicon, despite a `mac-os_arm64` asset existing.
- **`single-binary.md`** never installed `cortextool` at all — it ran it in Docker, and because a container has to reach Cortex, every command was **duplicated into a Linux block and a macOS/Windows block** (4 code blocks for 2 commands).

A host-installed `cortextool` reaches Cortex at `http://localhost:9009` (single-binary) and `http://localhost:8080` (microservices, via `kubectl port-forward`) on **every** platform. That collapses the Linux/macOS fork in `single-binary.md` to one command per step and retires the `--network host` troubleshooting entry.

Docker is kept as a single fallback in both guides — it is already a hard prerequisite and is the only path for native Windows without WSL2. Those fallbacks are bumped to **v0.21.1**.

## Drive-by fix: Compose network name

`single-binary.md` documented the network as `cortex-docs-getting-started_default`, but Compose v2 derives the project name from the *basename* of the project directory, and Step 1 has users `cd cortex/docs/getting-started`. `docker-compose.yaml` sets no `name:` and `.env` sets no `COMPOSE_PROJECT_NAME`, so the real network is `getting-started_default`. Confirmed with `docker network ls`:

```
955b0d4daa61   getting-started_default   bridge    local
```

This is a **pre-existing** bug, not one introduced here — anyone who followed the macOS/Windows instructions got `network cortex-docs-getting-started_default not found`.

## Testing

Ran both guides' commands against a live stack with `cortextool 0.21.1` installed from the tap:

```sh
cd docs/getting-started && docker compose up -d
cortextool rules sync rules.yaml alerts.yaml --id cortex --address http://localhost:9009
# Sync Summary: 0 Groups Created, 20 Groups Updated, 0 Groups Deleted
curl -H "X-Scope-OrgID: cortex" http://localhost:9009/prometheus/api/v1/rules | jq '.data.groups | length'
# 20
cortextool alertmanager load alertmanager-config.yaml --id cortex --address http://localhost:9009
# ok, config readable back via /api/v1/alerts
```

Also smoke-tested the Docker fallback with the corrected network name and `--address http://cortex:9009` — both `rules sync` and `alertmanager load` succeed.

`misspell -error docs` and the `check-white-noise` markdown check both pass.

### Note on a separate breakage

`docker compose up -d` on `master` currently leaves `cortex` in a restart loop, unrelated to this PR: `.env` pins `CORTEX_VERSION=v1.21.1`, but `runtime-config.yaml` uses `ruler_external_url` and `ruler_alert_generator_url_template`, which do not exist in v1.21.1:

```
failed to load runtime config: load file: yaml: unmarshal errors:
  line 12: field ruler_external_url not found in type validation.plain
  line 13: field ruler_alert_generator_url_template not found in type validation.plain
```

I verified the commands above with those per-tenant overrides temporarily blanked (they are irrelevant to `cortextool` reachability) and left `runtime-config.yaml` untouched in this PR. Happy to file a separate issue/PR for the version pin.

## Which issue(s) this PR fixes

N/A

## Checklist

- [x] Tested locally
- [ ] ~~Add entry to CHANGELOG.md~~ — docs-only, matching #7113 which created these guides