### PR TITLE
Track Prometheus and Thanos dependency ignores in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,23 @@ updates:
         exclude-patterns:
           - "github.com/thanos-io/thanos"
     ignore:
+      # The Prometheus and Thanos module families must be upgraded in lockstep with
+      # github.com/prometheus/prometheus and github.com/thanos-io/thanos, which we do
+      # manually — Dependabot bumping one of them alone breaks the build. See
+      # https://github.com/cortexproject/cortex/pull/7781, where client_golang v1.24
+      # changed api/prometheus/v1.LabelNames to return model.LabelNames.
+      #
+      # prometheus/prometheus itself is never auto-bumped. Note it maps Prometheus
+      # 3.x.y to tags v0.30x.y, so its "minor" bumps are real releases.
       - dependency-name: "github.com/prometheus/prometheus"
-        versions:
-          - ">=0.300.0-beta.0"
+      # For the rest of the Prometheus family, block major/minor (where the breaking
+      # changes land) but still allow patches, so security fixes land automatically.
+      - dependency-name: "github.com/prometheus/*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      # All thanos-io modules are on pseudo-versions, which don't classify as
+      # major/minor/patch, so update-types wouldn't filter them — ignore outright.
+      - dependency-name: "github.com/thanos-io/*"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## What this PR does

Moves the Prometheus/Thanos Dependabot ignore policy into `.github/dependabot.yml` so it no longer has to be hand-typed as `@dependabot ignore ...` comments on each grouped PR.

**Why:** the Prometheus and Thanos module families must move in lockstep with the pinned `github.com/prometheus/prometheus` (`v0.309.1`) and `github.com/thanos-io/thanos` (`v0.42.1-0.20260727122508-92397939e4cc`), which this repo bumps manually and jointly (precedent: #7535, #7691, #7740). When Dependabot moves one alone, the source breaks.

Most recently on #7781, `client_golang` v1.23.2 → v1.24.1 changed `api/prometheus/v1.LabelNames` to return `model.LabelNames` instead of `[]string`:

```
integration/e2ecortex/client.go:688:9: cannot use result (variable of slice type
"github.com/prometheus/common/model".LabelNames) as []string value in return statement
```

which failed `lint`, `test`, `test-no-race`, and `build-integration-tests` on both arches.

The config today only ignores `github.com/prometheus/prometheus`. The modules that actually keep breaking — `client_golang` and `common` — were unlisted, and Thanos was only *excluded from the group*, which is not an ignore (Dependabot still opened standalone Thanos PRs: #7263, #6899, #6858). The `@dependabot ignore` comments do persist, but only as state on Dependabot's side: invisible in the repo and unreviewable.

## Notes on the rules

- The blanket `prometheus/prometheus` entry replaces the old `versions: [">=0.300.0-beta.0"]` form while preserving its effect. Dropping the version range also blocks patch bumps of Prometheus itself, matching today's behavior — the wildcard rule alone would have started letting `v0.309.1 → v0.309.2` through.
- Dependabot's `dependency-name` glob is `File.fnmatch` without `FNM_PATHNAME`, so `*` crosses `/`. `github.com/prometheus/*` covers `client_golang`, `common`, `client_model`, `alertmanager`, `procfs`, `exporter-toolkit`, `otlptranslator`, and the nested `client_golang/exp` module. `github.com/thanos-io/*` covers `thanos`, `objstore`, and `promql-engine`.
- For the Prometheus family (other than `prometheus/prometheus`) only major/minor are ignored, so patch-level security fixes still land automatically.
- Thanos gets a blanket ignore rather than `update-types` because all three modules are on pseudo-versions (`objstore v0.0.0-20250804...`, `promql-engine v0.0.0-20260729...`, `thanos v0.42.1-0.20260727...`). A `v0.0.0-2025… → v0.0.0-2026…` bump is no semver level change at all, so an `update-types` filter would silently fail to match.
- Accepted cost: `procfs` and `client_model` minor bumps (which have landed cleanly before) now need a manual bump.
- The group's `exclude-patterns: ["github.com/thanos-io/thanos"]` is kept as-is. It is now redundant, but removing it would leave `go-dependencies:` an empty mapping, and it stays a useful safety net if the Thanos ignore is ever relaxed.

No `CHANGELOG.md` entry: CI-only change, not user-facing, consistent with prior `dependabot.yml` commits (`d595cba6c7`, `9430d35a3a`, `e6b828f95a`).

## Follow-up after merge

The earlier `@dependabot ignore github.com/prometheus/client_golang` / `... github.com/prometheus/common` comments created **all-versions** ignores on Dependabot's side, which would keep suppressing the patch bumps this config intends to permit. Once this merges, on an open Dependabot PR:

```
@dependabot unignore github.com/prometheus/client_golang
@dependabot unignore github.com/prometheus/common
```

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` parses cleanly; the `gomod` entry's `directories`, `groups`, `schedule`, and the `github-actions` entry are unchanged.
- `go.mod` pins untouched: `prometheus v0.309.1`, `client_golang v1.23.2`, `common v0.69.0`, `thanos v0.42.1-0.20260727122508-92397939e4cc`.
- Post-merge, effective conditions can be confirmed with `@dependabot show <module> ignore conditions` on an open Dependabot PR, and by checking that the next daily `go-dependencies` PR lists no `github.com/prometheus/*` rows and that no standalone Thanos PR appears.