### PR TITLE
Fix flaky pkg/compactor tests

### DIFF
--- a/pkg/compactor/compactor_paritioning_test.go
+++ b/pkg/compactor/compactor_paritioning_test.go
@@ -1016,13 +1016,14 @@ func TestPartitionCompactor_ShouldSkipOutOrOrderBlocks(t *testing.T) {
 
 	defer services.StopAndAwaitTerminated(context.Background(), c) //nolint:errcheck
 
-	// Wait until a run has completed.
-	cortex_testutil.Poll(t, 20*time.Second, true, func() any {
-		if _, err := os.Stat(path.Join(dir, "no-compact-mark.json")); err == nil {
-			return true
-		}
-		return false
+	// Wait until the block has been marked for no compaction. Poll on the counter that is
+	// asserted below rather than on the marker file: the file is written before the counter
+	// is incremented, so waiting on the file can let the assertion observe a stale 0.
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
+		return prom_testutil.ToFloat64(c.BlocksMarkedForNoCompaction)
 	})
+
+	assert.FileExists(t, path.Join(dir, "no-compact-mark.json"))
 
 	assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
 			# HELP cortex_compactor_blocks_marked_for_no_compaction_total Total number of blocks marked for no compact during a compaction run.

--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -196,7 +196,7 @@ func TestCompactor_SkipCompactionWhenCmkError(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -218,7 +218,7 @@ func TestCompactor_ShouldDoNothingOnNoUserBlocks(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -296,7 +296,7 @@ func TestCompactor_ShouldRetryCompactionOnFailureWhileDiscoveringUsersFromBucket
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until all retry attempts have completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsFailed)
 	})
 
@@ -392,7 +392,7 @@ func TestCompactor_ShouldIncrementCompactionErrorIfFailedToCompactASingleTenant(
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until all retry attempts have completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsFailed)
 	})
 
@@ -457,7 +457,7 @@ func TestCompactor_ShouldCompactAndRemoveUserFolder(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -527,7 +527,7 @@ func TestCompactor_ShouldIterateOverUsersAndRunCompaction(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -664,7 +664,7 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForDeletion(t *testing.T) {
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -798,7 +798,7 @@ func TestCompactor_ShouldNotCompactBlocksMarkedForSkipCompact(t *testing.T) {
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
-	cortex_testutil.Poll(t, time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -865,7 +865,7 @@ func TestCompactor_ShouldNotCompactBlocksForUsersMarkedForDeletion(t *testing.T)
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
 	// Wait until a run has completed.
-	cortex_testutil.Poll(t, time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
 	})
 
@@ -2003,7 +2003,7 @@ func TestCompactor_ShouldNotTreatInterruptionsAsErrors(t *testing.T) {
 	}, nil)
 	require.NoError(t, services.StartAndAwaitRunning(ctx, c))
 
-	cortex_testutil.Poll(t, 1*time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.CompactionRunsInterrupted)
 	})
 
@@ -2176,7 +2176,7 @@ func TestCompactor_FailedWithRetriableError(t *testing.T) {
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
-	cortex_testutil.Poll(t, 1*time.Second, 2.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 2.0, func() any {
 		return prom_testutil.ToFloat64(c.compactorMetrics.compactionErrorsCount.WithLabelValues("user-1", retriableError))
 	})
 
@@ -2231,7 +2231,7 @@ func TestCompactor_FailedWithHaltError(t *testing.T) {
 
 	require.NoError(t, services.StartAndAwaitRunning(context.Background(), c))
 
-	cortex_testutil.Poll(t, 1*time.Second, 1.0, func() any {
+	cortex_testutil.Poll(t, 20*time.Second, 1.0, func() any {
 		return prom_testutil.ToFloat64(c.compactorMetrics.compactionErrorsCount.WithLabelValues("user-1", haltError))
 	})
 


### PR DESCRIPTION
Fixes #7794.

Two independent test-synchronisation bugs. Both surface as `pkg/compactor` failing the
`test (amd64)` / `test (arm64)` job (`make test`, i.e. `go test -race`) with a **different
test each time**, which is why they read as generic flakiness. Test-only change; no product
code touched.

## 1. Sub-second `Poll` budgets (12 tests)

Twelve tests waited for a compaction run to complete with a **one-second** budget:

```go
cortex_testutil.Poll(t, time.Second, 1.0, func() any {
    return prom_testutil.ToFloat64(c.CompactionRunsCompleted)
})
```

`Compactor.running()` sleeps for a jitter of up to **10% of `CompactionInterval`** before the
initial compaction:

```go
// Insert jitter right before compaction starts to avoid multiple starting compactor to be in sync
case <-time.After(time.Duration(rand.Int63n(int64(float64(c.compactorCfg.CompactionInterval) * 0.1)))):
}
c.compactUsers(ctx)
```

`prepareConfig()` sets that interval to 5s, so **up to 500ms of the one-second budget can be
spent before compaction even starts**, leaving the run itself under half a second — on a runner
where this package takes 200-330s under `-race`. `expected 1, got 0` is that `Poll` timing out.

Raised to the `20*time.Second` used by most of the package (17 of the other `Poll` calls already
use it).

**Why this can't break the exact assertions that follow.** Several of these tests then assert on
exact state (`tsdbPlanner.AssertNumberOfCalls(t, "Plan", 2)`, exact log-line matching, exact
counter totals), so a second compaction run would break them. That can't happen:

- `running()` starts the interval ticker *after* the initial `compactUsers` returns, so runs never
  overlap and the counter stays at its post-run-1 value for a full interval (>=5s).
- `Poll` returns on first match rather than waiting out its budget, and its granularity is
  `d/100` = 200ms at 20s - comfortably inside that >=5s window.

So the tests still stop the compactor long before run 2, they just tolerate a slow run 1.

**Why not raise `CompactionInterval` instead** - the jitter is derived from it, so a longer
interval means a *longer* wait before the first run. That would make things worse, and it seems
worth recording since it's the intuitive first move.

## 2. Polling a different signal than the one asserted

`TestPartitionCompactor_ShouldSkipOutOrOrderBlocks` waited for the marker *file* and then asserted
on the *counter*:

```go
cortex_testutil.Poll(t, 20*time.Second, true, func() any {
    if _, err := os.Stat(path.Join(dir, "no-compact-mark.json")); err == nil { return true }
    return false
})

assert.NoError(t, prom_testutil.GatherAndCompare(registry, strings.NewReader(`
        cortex_compactor_blocks_marked_for_no_compaction_total 1
    `), ...))
```

The counter is incremented after the file is written, so the assertion could read a stale `0`
(observed: `-...total 0` / `+...total 1`). The 20s budget was never the problem here. Now it polls
the counter it asserts, and the marker file gets its own `assert.FileExists`.

This is the same class as #7565, which fixed two tests in this package by polling a better signal.

## Verification

- The six tests seen failing in CI and locally: `-race -count 10` -> pass.
- Whole package, `-race`, 4 consecutive runs -> pass (110s each in isolation).
- Full `go test -race ./...`, which is the condition that actually produced the failures: **zero
  `pkg/compactor` failures**. Before the change, the same command on the same machine failed
  `TestCompactor_FailedWithHaltError`, `TestCompactor_FailedWithRetriableError` and
  `TestCompactor_ShouldNotCompactBlocksMarkedForSkipCompact`.

No CHANGELOG entry, as this is test-only and not user-facing.