### PR TITLE
Add CODEOWNERS to auto-assign PR reviews to a maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners for the Cortex repository.
+#
+# Please keep this file in sync with MAINTAINERS.md and with membership of the
+# @cortexproject/maintainers GitHub team.
+#
+# The maintainers team is the default owner for the whole repository. GitHub's
+# team code review assignment picks a single maintainer per pull request, so a
+# PR does not notify everyone on the team.
+# See https://cortexmetrics.io/docs/contributing/how-to-add-a-maintainer/
+
+* @cortexproject/maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,8 @@
 | Friedrich Gonzalez | friedrichg@gmail.com  | @friedrichg   | Apple               |
 | Sungjin Lee        | tjdwls1201@gmail.com  | @SungJin1212  | KakaoEnterprise     |
 
+This table, the [`@cortexproject/maintainers` GitHub team](https://github.com/orgs/cortexproject/teams/maintainers) and `CODEOWNERS` must be kept in sync. The team is the code owner for the whole repository, and GitHub's team code review assignment requests a single maintainer per pull request from it.
+
 ### Triagers
 
 

--- a/docs/contributing/_index.md
+++ b/docs/contributing/_index.md
@@ -21,6 +21,8 @@ a piece of work is finished it should:
 * Include a CHANGELOG message if users of Cortex need to hear about what you did.
 * If you have made any changes to flags or config, run `make doc` and commit the changed files to update the config file documentation.
 
+Once a pull request is marked ready for review, a maintainer is automatically requested as reviewer, so there's no need to hunt for one. Draft pull requests are skipped until you mark them ready.
+
 ## Use of AI Tools
 
 Cortex permits the use of generative AI tools to assist with contributions. Contributors remain

--- a/docs/contributing/how-to-add-a-maintainer.md
+++ b/docs/contributing/how-to-add-a-maintainer.md
@@ -9,6 +9,7 @@ New maintainers are proposed by an existing maintainer and are elected by [major
 
 1. Submit a PR to add the new member to `MAINTAINERS`
 1. Invite to [GitHub organization](https://github.com/orgs/cortexproject/people)
+1. Add to the [`maintainers` GitHub team](https://github.com/orgs/cortexproject/teams/maintainers) — this is what makes them a code owner via `CODEOWNERS` and puts them in the review rotation
 1. Invite to [`cortex-team` group](https://groups.google.com/forum/#!forum/cortex-team)
 1. Invite to [Quay.io repository](https://quay.io/organization/cortexproject?tab=teams)
 1. Invite to [Docker Hub organization](https://hub.docker.com/u/cortexproject)
@@ -18,3 +19,5 @@ New maintainers are proposed by an existing maintainer and are elected by [major
 1. Invite to [maintainer's Google Docs](https://drive.google.com/drive/folders/1aT7-rx4hvYoB3EjvOeX1LHJhgH0Sawzb)
 1. Add to the Google Analytics property used for the website statistics
 1. Invite to credentials vault
+
+When a maintainer steps down, remove them from the [`maintainers` GitHub team](https://github.com/orgs/cortexproject/teams/maintainers) as well as from `MAINTAINERS`, so that the review rotation and the published list stay in sync.


### PR DESCRIPTION
Reviewer assignment has been entirely manual, which left review load uneven and PRs from outside contributors sitting unclaimed.

This adds a root `CODEOWNERS` naming `@cortexproject/maintainers` as the default owner for the whole repository. Paired with GitHub's team code review assignment, this requests **exactly one** named maintainer per pull request rather than notifying the whole team, so the rotation is even and someone is individually accountable.

This mirrors sibling CNCF projects: `prometheus/prometheus` uses `* @prometheus/default-maintainers`, `grafana/mimir` uses `* @grafana/mimir-maintainers`, `grafana/loki` uses `* @grafana/loki-team`. A `CODEOWNERS` file is also rewarded by CLOMonitor and OpenSSF Scorecard, both of which this repo carries badges for.

### Org-side setup (already done)

The `@cortexproject/maintainers` team is already configured, so this file resolves on merge:

- Team created with **visible** privacy (a *secret* team cannot be used in `CODEOWNERS` — GitHub skips the entry and requests nobody)
- Team granted **write** access to this repo explicitly (GitHub requires this even though all members already have admin individually)
- Code review assignment enabled: **round robin**, **1** reviewer, count-existing-requests on, team request removed once an individual is picked

### Scope

- Blanket `*` ownership only. No path-specific rules — with 6 maintainers and a blanket-owner model they add sync burden and rot without changing who is actually asked. Can be added later if a genuine specialist area emerges.
- **No branch protection change.** `require_code_owner_reviews` stays `false`; review assignment is advisory and merging continues to follow the `GOVERNANCE.md` two-positive-votes convention, enforced by humans.
- No CHANGELOG entry — this is repo tooling, not a user-facing change to the Cortex binary.

### Also included

- `docs/contributing/how-to-add-a-maintainer.md`: adding to the GitHub team is now a documented step, plus a note that removing a maintainer requires removing them from the team *and* `MAINTAINERS`.
- `MAINTAINERS.md`: reminder that the table, the team, and `CODEOWNERS` must stay in sync.
- `docs/contributing/_index.md`: tells contributors a maintainer is auto-assigned so they need not hunt for one.

### Expected behavior

| Situation | Behavior |
|---|---|
| PR from a fork by an outside contributor | Works normally; the base branch's `CODEOWNERS` applies. This is the main case being fixed. |
| Draft PR | No reviewer requested until marked ready. Intended. |
| PR authored by a maintainer | GitHub excludes the author, so one of the other 5 is picked. |
| All maintainers set to "Busy" | Degrades to notifying the team rather than nobody. |

Note: this PR does **not** auto-request a reviewer, because GitHub reads `CODEOWNERS` from the base branch and `master` does not have it yet. The first PR opened after this merges will be the real end-to-end test.
