### PR TITLE
Fix flaky integration TestSingleBinaryWithMemberlistScaling

### DIFF
--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -323,9 +323,7 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 		// TODO(#4360): Remove this when issue is resolved.
 		//   Wait until memberlist for all nodes has recognised the instance left.
 		//   This means that we will not gossip tombstones to leaving nodes.
-		for _, c := range instances {
-			require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(len(instances))), "memberlist_client_cluster_members_count"))
-		}
+		requireMemberlistMembersCount(t, instances, len(instances))
 	}
 	require.NoError(t, stop.Wait())
 
@@ -359,6 +357,66 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	}, 30*time.Second, 2*time.Second,
 		"expected all instances to have %f ring members and %f tombstones",
 		expectedRingMembers, expectedTombstones)
+}
+
+// memberlistConvergenceTimeout bounds how long we wait for every surviving instance to
+// notice that a stopped instance left the memberlist cluster.
+//
+// An instance learns about a departure in one of three ways, in increasing order of cost:
+//
+//  1. The "leave" message the departing instance gossips on shutdown. This usually arrives
+//     within a second, but it is best effort: it has a finite retransmit budget
+//     (RetransmitMult * ceil(log10(N+1)), 8 transmissions at 22 nodes) and during an
+//     aggressive scale down much of that budget is spent on peers that are already gone.
+//     Memberlist keeps gossiping to nodes that died less than GossipToTheDeadTime (30s)
+//     ago, and each such send blocks the single gossip goroutine for
+//     -memberlist.packet-dial-timeout (5s), because a removed container's address is
+//     blackholed and the dial ends in "i/o timeout" rather than "connection refused".
+//  2. The next push/pull full state sync (memberlist.PushPullInterval, 30s). This reliably
+//     repairs a missed leave, since a remote StateLeft is applied directly, but a sync can
+//     pick the departed instance itself and fail, costing another interval.
+//  3. Failure detection, which is far slower than either: with the ProbeInterval Cortex
+//     configures (5s) a given peer is probed roughly once every len(members) * 5s, and the
+//     suspicion timer then runs for SuspicionMult * log10(N+1) * ProbeInterval, starting at
+//     SuspicionMaxTimeoutMult (6x) that value and only shrinking as other nodes confirm the
+//     suspicion. No confirmation ever arrives here, because every other node already
+//     recorded the leave and ignores suspect messages for non-alive nodes. At 22 nodes that
+//     is ~160s of suspicion on top of the probe delay.
+//
+// So the budget has to cover several push/pull intervals. It used to be whatever the
+// per-service retry backoff gave (100 retries of up to 500ms, see newSingleBinary), which is
+// ~50s: one marginal sync window, and the test failed whenever a single leave message was
+// lost. See #7801.
+const memberlistConvergenceTimeout = 2 * time.Minute
+
+// requireMemberlistMembersCount waits until every instance reports exactly expectedMembers
+// in memberlist_client_cluster_members_count.
+func requireMemberlistMembersCount(t *testing.T, instances []*e2ecortex.CortexService, expectedMembers int) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		converged := true
+
+		for _, c := range instances {
+			metrics, err := c.SumMetrics([]string{"memberlist_client_cluster_members_count"})
+			if err != nil {
+				// Scraping can fail transiently while the cluster is churning, so retry
+				// instead of failing the test.
+				converged = false
+				t.Logf("%s: failed to fetch memberlist_client_cluster_members_count: %s\n", c.Name(), err)
+				continue
+			}
+
+			// Don't short circuit the check, so we log every instance which is behind.
+			if metrics[0] != float64(expectedMembers) {
+				converged = false
+				t.Logf("%s: memberlist_client_cluster_members_count=%f, expected %d\n", c.Name(), metrics[0], expectedMembers)
+			}
+		}
+
+		return converged
+	}, memberlistConvergenceTimeout, time.Second,
+		"expected all instances to see %d memberlist cluster members", expectedMembers)
 }
 
 func TestHATrackerWithMemberlistClusterSync(t *testing.T) {


### PR DESCRIPTION
Fixes #7801.

## What

`TestSingleBinaryWithMemberlistScaling` scales a single-binary memberlist cluster to 30 instances and tears it down to 3, one instance at a time. After each `s.Stop()` it waits for every survivor to report the reduced `memberlist_client_cluster_members_count`:

```go
// TODO(#4360): Remove this when issue is resolved.
//   Wait until memberlist for all nodes has recognised the instance left.
//   This means that we will not gossip tombstones to leaving nodes.
for _, c := range instances {
    require.NoError(t, c.WaitSumMetrics(e2e.Equals(float64(len(instances))), "memberlist_client_cluster_members_count"))
}
```

That wait had no timeout of its own. `WaitSumMetrics` polls with the service's generic retry backoff, which `newSingleBinary` sets to `MaxRetries: 100` of up to `500ms` — a container-readiness budget worth **~50 s**.

A departing instance's memberlist `leave` message is gossiped best effort. When a survivor misses it, the fast repair is memberlist's **push/pull full-state sync, which runs every 30 s**, so ~50 s buys one — at best two — repair opportunities, and one of those can be spent trying to sync with the instance that just went away.

That is exactly what happened in the run this fixes ([arm64 job](https://github.com/cortexproject/cortex/actions/runs/32510904119/job/96863336091)): after `cortex-22` was stopped, `cortex-3` logged `Push/Pull with cortex-22-e8b03be2 failed` **28 s later**. `pushPull()` only selects peers in `StateAlive` (`vendor/github.com/hashicorp/memberlist/state.go:633-639`), so `cortex-3` still had the departed instance *alive* at that point — it had neither received the leave nor yet suspected the node. The wait gave up **48.2 s** after the stop, reporting 22 members instead of 21, and `cortex-3`'s next push/pull was due roughly 10 s later. A remote `StateLeft` is applied directly by `mergeState` → `deadNode` (`state.go:1313-1315`), so that sync would have repaired it.

The other paths are slower still:

- **Gossip** retransmits a leave `RetransmitMult * ceil(log10(N+1))` = 8 times at 22 nodes, and during a fast scale down much of that budget goes to nodes dead for less than `GossipToTheDeadTime` (30 s), which memberlist keeps gossiping to (`state.go:575-595`). Each of those sends blocks memberlist's *single* gossip goroutine for `-memberlist.packet-dial-timeout` (5 s), because Docker blackholes a removed container's address so the dial ends in `i/o timeout` rather than `connection refused` (`pkg/ring/kv/memberlist/tcp_transport.go:521-542`). The regular ~5 s cadence of the `WriteTo failed` lines in the failing log is exactly this.
- **Failure detection** is slowest: with the `ProbeInterval` Cortex configures (5 s) a peer is probed about once every `len(members) * 5s` ≈ 110 s at 22 nodes, and the suspicion timer starts at `SuspicionMaxTimeoutMult` (6×) `SuspicionMult * log10(N+1) * ProbeInterval` ≈ **160 s**, shrinking only on confirmations that never arrive — every other node already recorded the leave and `suspectNode` ignores suspect messages for non-alive nodes (`state.go:1171-1174`).

## The change

The assertion and the metric are both correct, so they are unchanged. What was wrong is the budget: it was inherited from a readiness check rather than chosen for gossip convergence (added in 03911b6e02 / #4361, itself a workaround for #4360). This PR gives the wait an explicit budget derived from `PushPullInterval` — 2 minutes, i.e. four sync opportunities instead of one marginal window — documents the three convergence paths and their costs so the number isn't a mystery, logs which instances are still behind (mirroring the final tombstone assertion, which already does this and has "proven extremely useful"), and treats a transient scrape failure as "not converged yet" rather than aborting the wait outright the way `WaitSumMetrics` does.

This does not slow the test in the normal case: the wait returns on the first successful poll, and every earlier scale-down step in the referenced run converged in about 3.5 s.

## Alternatives considered

- **Reducing `maxCortex`** — weakens the coverage the test exists for ("these numbers seem enough to reliably reproduce some unwanted consequences of slow propagation"), and the suspicion timeout scales with `log10(N)` so it barely helps: 12 nodes still gives a ~130 s worst case.
- **Waiting on a different metric** — `memberlist_client_cluster_members_count` is the right signal for the stated intent.
- **Arch-aware tuning** — the mechanism is architecture-independent. #4289 and #4351 are from 2021, long before arm64 CI (#7068); arm64 only raises the probability (containers start ~6.3 s apart, 30 Cortex processes at `GOMAXPROCS=4`).
- **Fixing the 5 s blocking dial to blackholed peers** on memberlist's gossip goroutine. This is a genuine robustness weakness in production too — a handful of unreachable peers can stall a node's outbound gossip — but it is a product change, not a test fix. Called out in #7801 for separate consideration.

Worth noting that the workaround this PR repairs only partially achieves its stated goal: memberlist keeps gossiping to a node for `GossipToTheDeadTime` (30 s) *after* marking it dead, so the departing node stays in the gossip pool past the point where the member count drops. Fully avoiding that would mean sleeping 30 s per scale-down step. #4360 remains the real fix.

No CHANGELOG entry: test-only change, matching a7e4c7844e ("Fix flaky pkg/compactor tests", #7796).

## Verification

- `go vet -tags "integration,requires_docker,integration_memberlist" ./integration/...` — clean, no output.
- `gofmt -l` / `goimports -local github.com/cortexproject/cortex -l` on the changed file — no output.

**I was not able to run this integration test.** It needs Docker and ~31 containers, and the memberlist integration tests do not run in my local environment at all: the *unmodified* `TestSingleBinaryWithMemberlist/default` fails there on the very first instance (`the service cortex-1 is not ready; ... connect: connection refused`, container exits after ~2 s), and `TestSingleBinaryWithMemberlistScaling` died during scale-up at `cortex-10` for the same reason — both in `StartAndWaitReady`, code this PR does not touch. My environment is also darwin/arm64, which is not the arm64 Linux CI runner, so a local pass would not have proven the flake fixed either way. CI on this PR is the real check.

Since the flake is probabilistic, a single green CI run does not prove much; the argument for the fix rests on the timing analysis above — the wait budget was ~1.6 push/pull intervals and is now 4.
