### PR TITLE
Build faillint from the main module instead of `go install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ lint:
 	golangci-lint run
 
 	# Ensure no blocklisted package is imported.
-	GOFLAGS="-tags=requires_docker,integration,integration_alertmanager,integration_backward_compatibility,integration_configs_db,integration_memberlist,integration_querier,integration_ruler,integration_query_fuzz,integration_remote_write_v2" faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
+	GOFLAGS="-tags=requires_docker,integration,integration_alertmanager,integration_backward_compatibility,integration_configs_db,integration_memberlist,integration_querier,integration_ruler,integration_query_fuzz,integration_remote_write_v2" go tool faillint -paths "github.com/bmizerany/assert=github.com/stretchr/testify/assert,\
 		golang.org/x/net/context=context,\
 		sync/atomic=go.uber.org/atomic,\
 		github.com/prometheus/client_golang/prometheus.{MultiError}=github.com/prometheus/prometheus/tsdb/errors.{NewMulti},\
@@ -166,20 +166,20 @@ lint:
 		github.com/weaveworks/common/user.{ExtractOrgIDFromHTTPRequest}=github.com/cortexproject/cortex/pkg/tenant.{ExtractTenantIDFromHTTPRequest}" ./pkg/... ./cmd/... ./tools/... ./integration/...
 
 	# Ensure clean pkg structure.
-	faillint -paths "\
+	go tool faillint -paths "\
 		github.com/cortexproject/cortex/pkg/scheduler,\
 		github.com/cortexproject/cortex/pkg/frontend,\
 		github.com/cortexproject/cortex/pkg/frontend/transport,\
 		github.com/cortexproject/cortex/pkg/frontend/v1,\
 		github.com/cortexproject/cortex/pkg/frontend/v2" \
 		./pkg/querier/...
-	faillint -paths "github.com/cortexproject/cortex/pkg/querier/..." ./pkg/scheduler/...
-	faillint -paths "github.com/cortexproject/cortex/pkg/storage/tsdb/..." ./pkg/storage/bucket/...
-	faillint -paths "github.com/cortexproject/cortex/pkg/..." ./pkg/alertmanager/alertspb/...
-	faillint -paths "github.com/cortexproject/cortex/pkg/..." ./pkg/ruler/rulespb/...
+	go tool faillint -paths "github.com/cortexproject/cortex/pkg/querier/..." ./pkg/scheduler/...
+	go tool faillint -paths "github.com/cortexproject/cortex/pkg/storage/tsdb/..." ./pkg/storage/bucket/...
+	go tool faillint -paths "github.com/cortexproject/cortex/pkg/..." ./pkg/alertmanager/alertspb/...
+	go tool faillint -paths "github.com/cortexproject/cortex/pkg/..." ./pkg/ruler/rulespb/...
 
 	# Ensure the query path is supporting multiple tenants
-	faillint -paths "\
+	go tool faillint -paths "\
 		github.com/cortexproject/cortex/pkg/tenant.{TenantID}=github.com/cortexproject/cortex/pkg/tenant.{TenantIDs}" \
 		./pkg/scheduler/... \
 		./pkg/frontend/... \
@@ -189,7 +189,7 @@ lint:
 		./pkg/querier/tripperware/queryrange/...
 
 	# Ensure packages that no longer use a global logger don't reintroduce it
-	faillint -paths "github.com/cortexproject/cortex/pkg/util/log.{Logger}" \
+	go tool faillint -paths "github.com/cortexproject/cortex/pkg/util/log.{Logger}" \
 		./pkg/alertmanager/alertstore/... \
 		./pkg/ingester/... \
 		./pkg/flusher/... \

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -23,7 +23,6 @@ RUN go install github.com/client9/misspell/cmd/misspell@v0.3.4 &&\
 	go install github.com/golang/protobuf/protoc-gen-go@v1.3.1 &&\
 	go install github.com/gogo/protobuf/protoc-gen-gogoslick@v1.3.0 &&\
 	go install github.com/weaveworks/tools/cover@bdd647e92546027e12cdde3ae0714bb495e43013 &&\
-	go install github.com/fatih/faillint@v1.15.0 &&\
 	go install github.com/campoy/embedmd@v1.0.0 &&\
 	rm -rf /go/pkg /go/src /root/.cache
 

--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	cloud.google.com/go/iam v1.5.3 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	cloud.google.com/go/storage v1.56.0 // indirect
+	dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
@@ -156,6 +157,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/fatih/color v1.19.0 // indirect
+	github.com/fatih/faillint v1.15.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.10.0 // indirect
 	github.com/go-chi/chi/v5 v5.2.4 // indirect
@@ -354,3 +356,5 @@ exclude github.com/envoyproxy/go-control-plane/envoy v1.32.3
 
 // Required by Prometheus v0.308+ config package for OTLP translation strategy types.
 replace github.com/prometheus/otlptranslator => github.com/prometheus/otlptranslator v1.0.0
+
+tool github.com/fatih/faillint

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ cloud.google.com/go/storage v1.56.0 h1:iixmq2Fse2tqxMbWhLWC9HfBj1qdxqAmiK8/eqtsL
 cloud.google.com/go/storage v1.56.0/go.mod h1:Tpuj6t4NweCLzlNbw9Z9iwxEkrSem20AetIeH/shgVU=
 cloud.google.com/go/trace v1.11.7 h1:kDNDX8JkaAG3R2nq1lIdkb7FCSi1rCmsEtKVsty7p+U=
 cloud.google.com/go/trace v1.11.7/go.mod h1:TNn9d5V3fQVf6s4SCveVMIBS2LJUqo73GACmq/Tky0s=
+dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363 h1:o4lAkfETerCnr1kF9/qwkwjICnU+YLHNDCM8h2xj7as=
+dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363/go.mod h1:WG7q7swWsS2f9PYpt5DoEP/EBYWx8We5UoRltn9vJl8=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 h1:JXg2dwJUmPB9JmtVmdEB16APJ7jurfbY5jnfXpJoRMc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0/go.mod h1:YD5h/ldMsG0XiIw7PdyNhLxaM317eFh5yNLccNfGdyw=
@@ -334,6 +336,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
+github.com/fatih/faillint v1.15.0 h1:GBsqRgd/uPvo7AdunUoM4oEBVCE7KCxz77J0f9IKr2w=
+github.com/fatih/faillint v1.15.0/go.mod h1:xg4qfUwfXviSkDlZqJ7cDaf0JyOgR2Hx+a977rJt5Rc=
 github.com/felixge/fgprof v0.9.5 h1:8+vR6yu2vvSKn08urWyEuxx75NWPEvybbkBirEpsbVY=
 github.com/felixge/fgprof v0.9.5/go.mod h1:yKl+ERSa++RYOs32d8K6WEXCB4uXdLls4ZaZPpayhMM=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/vendor/dmitri.shuralyov.com/go/generated/LICENSE
+++ b/vendor/dmitri.shuralyov.com/go/generated/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2017 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/dmitri.shuralyov.com/go/generated/generated.go
+++ b/vendor/dmitri.shuralyov.com/go/generated/generated.go
@@ -1,0 +1,80 @@
+// Package generated provides a function that parses a Go file and reports
+// whether it contains a "// Code generated … DO NOT EDIT." line comment.
+//
+// It implements the specification at https://golang.org/s/generatedcode.
+//
+// The first priority is correctness (no false negatives, no false positives).
+// It must return accurate results even if the input Go source code is not gofmted.
+//
+// The second priority is performance. The current version uses bufio.Reader and
+// ReadBytes. Performance can be optimized further by using lower level I/O
+// primitives and allocating less. That can be explored later. A lot of the time
+// is spent on reading the entire file without being able to stop early,
+// since the specification allows the comment to appear anywhere in the file.
+package generated
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+)
+
+// Parse parses the source code of a single Go source file
+// provided via src, and reports whether the file contains
+// a "// Code generated ... DO NOT EDIT." line comment
+// matching the specification at https://golang.org/s/generatedcode:
+//
+// 	Generated files are marked by a line of text that matches
+// 	the regular expression, in Go syntax:
+//
+// 		^// Code generated .* DO NOT EDIT\.$
+//
+// 	The .* means the tool can put whatever folderol it wants in there,
+// 	but the comment must be a single line and must start with Code generated
+// 	and end with DO NOT EDIT., with a period.
+//
+// 	The text may appear anywhere in the file.
+func Parse(src io.Reader) (hasGeneratedComment bool, err error) {
+	br := bufio.NewReader(src)
+	for {
+		s, err := br.ReadBytes('\n')
+		if err == io.EOF {
+			return containsComment(s), nil
+		} else if err != nil {
+			return false, err
+		}
+		if len(s) >= 2 && s[len(s)-2] == '\r' {
+			s = s[:len(s)-2] // Trim "\r\n".
+		} else {
+			s = s[:len(s)-1] // Trim "\n".
+		}
+		if containsComment(s) {
+			return true, nil
+		}
+	}
+}
+
+// containsComment reports whether a line of Go source code s (without newline character)
+// contains the generated comment.
+func containsComment(s []byte) bool {
+	return len(s) >= len(prefix)+len(suffix) &&
+		bytes.HasPrefix(s, prefix) &&
+		bytes.HasSuffix(s, suffix)
+}
+
+var (
+	prefix = []byte("// Code generated ")
+	suffix = []byte(" DO NOT EDIT.")
+)
+
+// ParseFile opens the file specified by filename and uses Parse to parse it.
+// If the source couldn't be read, the error indicates the specific failure.
+func ParseFile(filename string) (hasGeneratedComment bool, err error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	return Parse(f)
+}

--- a/vendor/github.com/fatih/faillint/.gitignore
+++ b/vendor/github.com/fatih/faillint/.gitignore
@@ -1,0 +1,17 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+faillint/testdata/pkg
+
+# IDE workspace files
+/.vscode/

--- a/vendor/github.com/fatih/faillint/.goreleaser.yml
+++ b/vendor/github.com/fatih/faillint/.goreleaser.yml
@@ -1,0 +1,37 @@
+project_name: faillint
+release:
+  prerelease: auto # don't publish release with -rc1,-pre, etc suffixes
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+     - -s -w -X main.version={{.Version}} -X main.date={{.Date}}
+    binary: "faillint"   
+nfpms:
+  - maintainer: Fatih Arslan
+    description: Report unwanted Go import path and declaration usages
+    homepage: https://github.com/fatih/faillint
+    license: BSD 3-Clause
+    formats:
+    - deb
+    - rpm
+    replacements:
+      darwin: macOS
+archives:
+  - replacements:
+      darwin: macOS
+    format_overrides:
+      - goos: windows
+        format: zip
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/vendor/github.com/fatih/faillint/LICENSE
+++ b/vendor/github.com/fatih/faillint/LICENSE
@@ -1,0 +1,62 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, Fatih Arslan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This software includes some portions from Go. Go is used under the terms of the
+BSD like license.
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The Go gopher was designed by Renee French. http://reneefrench.blogspot.com/ The design is licensed under the Creative Commons 3.0 Attributions license. Read this article for more details: https://blog.golang.org/gopher

--- a/vendor/github.com/fatih/faillint/README.md
+++ b/vendor/github.com/fatih/faillint/README.md
@@ -1,0 +1,166 @@
+# faillint [![](https://github.com/fatih/faillint/workflows/build/badge.svg)](https://github.com/fatih/faillint/actions)
+
+Faillint is a simple Go linter that fails when a specific set of import paths
+or exported path's functions, constant, vars or types are used. It's meant to be
+used in CI/CD environments to catch rules you want to enforce in your projects.
+
+As an example, you could enforce the usage of `github.com/pkg/errors` instead
+of the `errors` package. To prevent the usage of the `errors` package, you can
+configure `faillint` to fail whenever someone imports the `errors` package in
+this case. To make sure `fmt.Errorf` is not used for creating errors as well,
+you can configure to fail on such single function of `fmt` as well.
+
+![faillint](https://user-images.githubusercontent.com/438920/74105802-f7158300-4b15-11ea-8e23-16be5cd3b971.gif)
+
+## Install
+
+```bash
+go install github.com/fatih/faillint@latest
+```
+
+## Example
+
+Assume we have the following file:
+
+```go
+package a
+
+import (
+        "errors"
+)
+
+func foo() error {
+        return errors.New("bar!")
+}
+```
+
+Let's run `faillint` to check if `errors` import is used and report it:
+
+```
+$ faillint -paths "errors=github.com/pkg/errors" a.go
+a.go:4:2: package "errors" shouldn't be imported, suggested: "github.com/pkg/errors"
+```
+
+## Usage
+
+`faillint` works on a file, directory or a Go package:
+
+```sh
+$ faillint -paths "errors,fmt.{Errorf}" foo.go # pass a file
+$ faillint -paths "errors,fmt.{Errorf}" ./...  # recursively analyze all files
+$ faillint -paths "errors,fmt.{Errorf}" github.com/fatih/gomodifytags # or pass a package
+```
+
+By default, `faillint` will not check any import paths. You need to explicitly
+define it with the `-paths` flag, which is comma-separated list. Some examples are:
+
+```
+# Fail if the errors package is used.
+-paths "errors"
+
+# Fail if the old context package is imported.
+-paths "golang.org/x/net/context"
+
+# Fail both on stdlib log and errors package to enforce other internal libraries.
+-paths "log,errors"
+
+# Fail if any of Print, Printf of Println function were used from fmt library.
+-paths "fmt.{Print,Printf,Println}"
+
+# Fail if the package is imported including sub paths starting with
+  "golang.org/x/net/". In example: `golang.org/x/net/context`, 
+  `golang.org/x/net/nettest`, .nettest`, ...
+-paths "golang.org/x/net/..."
+```
+
+If you have a preferred import path to suggest, append the suggestion after a `=` character:
+
+```
+# Fail if the errors package is used and suggest to use github.com/pkg/errors.
+-paths "errors=github.com/pkg/errors"
+
+# Fail for the old context import path and suggest to use the stdlib context.
+-paths "golang.org/x/net/context=context"
+
+# Fail both on stdlib log and errors package to enforce other libraries.
+-paths "log=go.uber.org/zap,errors=github.com/pkg/errors"
+
+# Fail on fmt.Errorf and suggest the Errorf function from github.compkg/errors instead.
+-paths "fmt.{Errorf}=github.com/pkg/errors.{Errorf}"
+```
+
+### Ignoring problems
+
+If you want to ignore a problem reported by `faillint` you can add a lint directive based on [staticcheck](https://staticcheck.io)'s design.
+
+#### Line-based lint directives
+
+Line-based lint directives can be applied to imports or functions you want to tolerate.  The format is,
+
+```go
+//lint:ignore faillint reason
+```
+
+For example,
+
+```go
+package a
+
+import (
+        //lint:ignore faillint Whatever your reason is.
+        "errors"
+        "fmt" //lint:ignore faillint Whatever your reason is.
+)
+
+func foo() error {
+        //lint:ignore faillint Whatever your reason is.
+        return errors.New("bar!")
+}
+```
+
+#### File-based lint directives
+
+File-based lint directives can be applied to ignore `faillint` problems in a whole file.  The format is,
+
+```go
+//lint:file-ignore faillint reason
+```
+
+This may be placed anywhere in the file but conventionally it should be placed at, or near, the top of the file.
+
+For example,
+
+```go
+//lint:file-ignore faillint This file should be ignored by faillint.
+
+package a
+
+import (
+        "errors"
+)
+
+func foo() error {
+        return errors.New("bar!")
+}
+```
+
+## The need for this tool?
+
+Most of these checks should be probably detected during the review cycle. But
+it's totally normal to accidentally import them (we're all humans in the end).
+
+Second, tools like `goimports` favors certain packages. As an example going
+forward if you decided to use `github.com/pkg/errors` in you project, and write
+`errors.New()` in a new file, `goimports` will automatically import the
+`errors` package (and not `github.com/pkg/errors`). The code will perfectly
+compile. `faillint` would be able to detect and report it to you.
+
+## Credits
+
+This tool is built on top of the excellent `go/analysis` package that makes it
+easy to write custom analyzers in Go. If you're interested in writing a tool,
+check out my **[Using go/analysis to write a custom
+linter](https://arslan.io/2019/06/13/using-go-analysis-to-write-a-custom-linter/)**
+blog post.
+
+Part of the code is modified and based on [astutil.UsesImport](https://pkg.go.dev/golang.org/x/tools/go/ast/astutil?tab=doc#UsesImport)

--- a/vendor/github.com/fatih/faillint/faillint/faillint.go
+++ b/vendor/github.com/fatih/faillint/faillint/faillint.go
@@ -1,0 +1,357 @@
+// Package faillint defines an Analyzer that fails when a package is imported
+// that matches against a set of defined packages.
+package faillint
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"dmitri.shuralyov.com/go/generated"
+	"golang.org/x/tools/go/analysis"
+)
+
+const (
+	// ignoreKey is used in a faillint directive to ignore a line-based problem.
+	ignoreKey = "ignore"
+	// fileIgnoreKey is used in a faillint directive to ignore a whole file.
+	fileIgnoreKey = "file-ignore"
+	// missingReasonTemplate is used when a faillint directive is missing a reason.
+	missingReasonTemplate = "missing reason on faillint:%s directive"
+	// unrecognizedOptionTemplate is used when a faillint directive has an option other than ignore or file-ignore.
+	unrecognizedOptionTemplate = "unrecognized option on faillint directive: %s"
+
+	unspecifiedUsage = "unspecified"
+)
+
+var (
+	// Analyzer is a global instance of the linter.
+	// DEPRECATED: Use faillint.New instead.
+	Analyzer = NewAnalyzer()
+
+	// pathsRegexp represents a regexp that is used to parse -paths flag.
+	// It parses flag content in set of 3 subgroups:
+	//
+	// * import: Mandatory part. Go import path in URL format to be unwanted or have unwanted declarations.
+	// * recursive: Optional part. Import paths in the form of foo/bar/... indicates that all recursive sub matchs should be also matched.
+	// * declarations: Optional declarations in `{ }`. If set, using the import is allowed expect give declarations.
+	// * suggestion: Optional suggestion to print when unwanted import or declaration is found.
+	pathsRegexp = regexp.MustCompile(`(?P<import>[\w/.-]+[\w])(/?(?P<recursive>\.\.\.)|)(\.?{(?P<declarations>[\w-,]+)}|)(=(?P<suggestion>[\w/.-]+[\w](\.?{[\w-,]+}|))|)`)
+)
+
+// path represents a single parsed directive parsed with the pathsRegexp regex
+type path struct {
+	// imp contains the full import path
+	imp string
+
+	// recursive is true if the import path should encapsulate all sub paths
+	// for the given import path as well.
+	recursive bool
+
+	// declarations contains the declarations to fail for the given import path
+	decls []string
+
+	// sugg defines the suggestion for a given import path
+	sugg string
+}
+
+type faillint struct {
+	paths       string // -paths flag
+	ignoretests bool   // -ignore-tests flag
+	onlyTests   bool   // -only-tests flag
+}
+
+// NewAnalyzer create a faillint analyzer.
+func NewAnalyzer() *analysis.Analyzer {
+	f := faillint{
+		paths:       "",
+		ignoretests: false,
+		onlyTests:   false,
+	}
+	a := &analysis.Analyzer{
+		Name:             "faillint",
+		Doc:              "Report unwanted import path or exported declaration usages",
+		Run:              f.run,
+		RunDespiteErrors: true,
+	}
+
+	a.Flags.StringVar(&f.paths, "paths", "", `import paths or exported declarations (i.e: functions, constant, types or variables) to fail. E.g.:
+
+Fail on the usage of errors and fmt.Errorf. Also suggest packages for the failures
+  -paths errors=github.com/pkg/errors,fmt.{Errorf}=github.com/pkg/errors.{Errorf}
+
+Fail on the usage of fmt.Println, fmt.Print and fmt.Printf
+  -paths fmt.{Println,Print,Printf}
+
+Fail on the usage of prometheus.DefaultGatherer and prometheus.MustRegister
+  -paths github.com/prometheus/client_golang/prometheus.{DefaultGatherer,MustRegister}
+
+Fail on the usage of errors, golang.org/x/net and all sub packages under golang.org/x/net
+  -paths errors,golang.org/x/net/...`)
+
+	a.Flags.BoolVar(&f.ignoretests, "ignore-tests", false, "ignore all _test.go files")
+	a.Flags.BoolVar(&f.onlyTests, "only-tests", false, "include only _test.go files")
+	return a
+}
+
+func trimAllWhitespaces(str string) string {
+	var b strings.Builder
+	b.Grow(len(str))
+	for _, ch := range str {
+		if !unicode.IsSpace(ch) {
+			b.WriteRune(ch)
+		}
+	}
+	return b.String()
+}
+
+// run is the runner for an analysis pass.
+func (f *faillint) run(pass *analysis.Pass) (interface{}, error) {
+	if f.paths == "" {
+		return nil, nil
+	}
+
+	if f.ignoretests && f.onlyTests {
+		return nil, errors.New("--ignore-tests and --only-tests flags cannot be used together")
+	}
+
+	for _, file := range pass.Files {
+		filename := pass.Fset.File(file.Package).Name()
+		isGenerated, err := generated.ParseFile(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		if isGenerated {
+			continue
+		}
+
+		isTestFile := strings.Contains(pass.Fset.File(file.Package).Name(), "_test.go")
+
+		if f.ignoretests && isTestFile {
+			continue
+		}
+
+		if f.onlyTests && !isTestFile {
+			continue
+		}
+
+		if anyHasDirective(pass, file.Comments, fileIgnoreKey) {
+			continue
+		}
+		commentMap := ast.NewCommentMap(pass.Fset, file, file.Comments)
+		for _, path := range parsePaths(f.paths) {
+			specs := importSpec(file, path.imp, path.recursive)
+			if len(specs) == 0 {
+				continue
+			}
+
+			for _, spec := range specs {
+				if usageHasDirective(pass, commentMap, spec, spec.Pos(), ignoreKey) {
+					continue
+				}
+
+				usages := importUsages(pass, commentMap, file, spec)
+				if len(usages) == 0 {
+					continue
+				}
+
+				if _, ok := usages[unspecifiedUsage]; ok || len(path.decls) == 0 {
+					// File using unwanted import. Report.
+					msg := fmt.Sprintf("package %q shouldn't be imported", importPath(spec))
+					if path.sugg != "" {
+						msg += fmt.Sprintf(", suggested: %q", path.sugg)
+					}
+					pass.Reportf(spec.Path.Pos(), msg)
+					continue
+				}
+
+				// Not all usages are forbidden. Report only unwanted declarations.
+				for _, declaration := range path.decls {
+					positions, ok := usages[declaration]
+					if !ok {
+						continue
+					}
+					msg := fmt.Sprintf("declaration %q from package %q shouldn't be used", declaration, importPath(spec))
+					if path.sugg != "" {
+						msg += fmt.Sprintf(", suggested: %q", path.sugg)
+					}
+					for _, pos := range positions {
+						pass.Reportf(pos, msg)
+					}
+				}
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+// importUsages reports all exported declaration used for a given import.
+func importUsages(pass *analysis.Pass, commentMap ast.CommentMap, f *ast.File, spec *ast.ImportSpec) map[string][]token.Pos {
+	importRef := spec.Name.String()
+	switch importRef {
+	case "<nil>":
+		importRef, _ = strconv.Unquote(spec.Path.Value)
+		// If the package importRef is not explicitly specified,
+		// make an educated guess. This is not guaranteed to be correct.
+		lastSlash := strings.LastIndex(importRef, "/")
+		if lastSlash != -1 {
+			importRef = importRef[lastSlash+1:]
+		}
+	case "_", ".":
+		// Not sure if this import is used - on the side of caution, report special "unspecified" usage.
+		return map[string][]token.Pos{unspecifiedUsage: nil}
+	}
+	usages := map[string][]token.Pos{}
+
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if isTopName(sel.X, importRef) {
+			if usageHasDirective(pass, commentMap, n, sel.Sel.NamePos, ignoreKey) {
+				return true
+			}
+			usages[sel.Sel.Name] = append(usages[sel.Sel.Name], sel.Sel.NamePos)
+		}
+		return true
+	})
+	return usages
+}
+
+// importSpecs returns all import specs for f import statements importing path.
+func importSpec(f *ast.File, path string, recursive bool) (imports []*ast.ImportSpec) {
+	for _, s := range f.Imports {
+		impPath := importPath(s)
+		if impPath == path {
+			imports = append(imports, s)
+		} else if recursive && strings.HasPrefix(impPath, path+"/") {
+			// match all subpaths as well, i.e:
+			//   impPath = golang.org/x/net/context
+			//      path = golang.org/x/net
+			// We add the "/" so we don't match packages with dashes, such as
+			// `golang.org/x/net-
+			imports = append(imports, s)
+		}
+	}
+	return imports
+}
+
+// importPath returns the unquoted import path of s,
+// or "" if the path is not properly quoted.
+func importPath(s *ast.ImportSpec) string {
+	t, err := strconv.Unquote(s.Path.Value)
+	if err == nil {
+		return t
+	}
+	return ""
+}
+
+// isTopName returns true if n is a top-level unresolved identifier with the given name.
+func isTopName(n ast.Expr, name string) bool {
+	id, ok := n.(*ast.Ident)
+	return ok && id.Name == name && id.Obj == nil
+}
+
+func parseDirective(pass *analysis.Pass, c *ast.Comment) (option string) {
+	s := c.Text
+	if !strings.HasPrefix(s, "//lint:") {
+		return ""
+	}
+	s = strings.TrimPrefix(s, "//lint:")
+	fields := strings.SplitN(s, " ", 3)
+
+	if len(fields) < 2 {
+		return ""
+	}
+
+	if fields[1] != "faillint" {
+		return ""
+	}
+
+	if fields[0] != ignoreKey && fields[0] != fileIgnoreKey {
+		pass.Reportf(c.Pos(), unrecognizedOptionTemplate, fields[0])
+		return ""
+	}
+
+	if len(fields) < 3 {
+		pass.Reportf(c.Pos(), missingReasonTemplate, fields[0])
+		return ""
+	}
+
+	return fields[0]
+}
+
+func anyHasDirective(pass *analysis.Pass, cgs []*ast.CommentGroup, option string) bool {
+	for _, cg := range cgs {
+		if hasDirective(pass, cg, option) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDirective(pass *analysis.Pass, cg *ast.CommentGroup, option string) bool {
+	if cg == nil {
+		return false
+	}
+	for _, c := range cg.List {
+		if parseDirective(pass, c) == option {
+			return true
+		}
+	}
+	return false
+}
+
+func usageHasDirective(pass *analysis.Pass, cm ast.CommentMap, n ast.Node, p token.Pos, option string) bool {
+	for _, cg := range cm[n] {
+		if hasDirective(pass, cg, ignoreKey) {
+			return true
+		}
+	}
+	// Try to find an "enclosing" node which the ast.CommentMap will
+	// thus have associated comments to this field selector.
+	for node := range cm {
+		if p >= node.Pos() && p <= node.End() {
+			for _, cg := range cm[node] {
+				if hasDirective(pass, cg, option) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func parsePaths(paths string) []path {
+	pathGroups := pathsRegexp.FindAllStringSubmatch(trimAllWhitespaces(paths), -1)
+
+	parsed := make([]path, 0, len(pathGroups))
+	for _, group := range pathGroups {
+		p := path{}
+		for i, name := range pathsRegexp.SubexpNames() {
+			switch name {
+			case "import":
+				p.imp = group[i]
+			case "recursive":
+				p.recursive = group[i] != ""
+			case "suggestion":
+				p.sugg = group[i]
+			case "declarations":
+				if group[i] == "" {
+					break
+				}
+				p.decls = strings.Split(group[i], ",")
+			}
+		}
+		parsed = append(parsed, p)
+	}
+	return parsed
+}

--- a/vendor/github.com/fatih/faillint/main.go
+++ b/vendor/github.com/fatih/faillint/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/fatih/faillint/faillint"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+var (
+	version string
+	date    string
+)
+
+func main() {
+	// this is a small hack to implement the -V flag that is part of
+	// go/analysis framework. It'll allow us to print the version with -V, but
+	// the --help message will print the flags of the analyzer
+	ff := flag.NewFlagSet("faillint", flag.ContinueOnError)
+	v := ff.Bool("V", false, "print version and exit")
+	ff.Usage = func() {}
+	ff.SetOutput(io.Discard)
+
+	ff.Parse(os.Args[1:])
+	if *v {
+		fmt.Printf("faillint version %s (%s)\n", version, date)
+		os.Exit(0)
+	}
+
+	singlechecker.Main(faillint.NewAnalyzer())
+}

--- a/vendor/golang.org/x/tools/go/analysis/analysis.go
+++ b/vendor/golang.org/x/tools/go/analysis/analysis.go
@@ -1,0 +1,269 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package analysis
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"reflect"
+	"time"
+)
+
+// An Analyzer describes an analysis function and its options.
+type Analyzer struct {
+	// The Name of the analyzer must be a valid Go identifier
+	// as it may appear in command-line flags, URLs, and so on.
+	Name string
+
+	// Doc is the documentation for the analyzer.
+	// The part before the first "\n\n" is the title
+	// (no capital or period, max ~60 letters).
+	Doc string
+
+	// URL holds an optional link to a web page with additional
+	// documentation for this analyzer.
+	URL string
+
+	// Flags defines any flags accepted by the analyzer.
+	// The manner in which these flags are exposed to the user
+	// depends on the driver which runs the analyzer.
+	Flags flag.FlagSet
+
+	// Run applies the analyzer to a package.
+	// It returns an error if the analyzer failed.
+	//
+	// On success, the Run function may return a result
+	// computed by the Analyzer; its type must match ResultType.
+	// The driver makes this result available as an input to
+	// another Analyzer that depends directly on this one (see
+	// Requires) when it analyzes the same package.
+	//
+	// To pass analysis results between packages (and thus
+	// potentially between address spaces), use Facts, which are
+	// serializable.
+	Run func(*Pass) (any, error)
+
+	// RunDespiteErrors allows the driver to invoke
+	// the Run method of this analyzer even on a
+	// package that contains parse or type errors.
+	// The [Pass.TypeErrors] field may consequently be non-empty.
+	RunDespiteErrors bool
+
+	// Requires is a set of analyzers that must run successfully
+	// before this one on a given package. This analyzer may inspect
+	// the outputs produced by each analyzer in Requires.
+	// The graph over analyzers implied by Requires edges must be acyclic.
+	//
+	// Requires establishes a "horizontal" dependency between
+	// analysis passes (different analyzers, same package).
+	Requires []*Analyzer
+
+	// ResultType is the type of the optional result of the Run function.
+	ResultType reflect.Type
+
+	// FactTypes indicates that this analyzer imports and exports
+	// Facts of the specified concrete types.
+	// An analyzer that uses facts may assume that its import
+	// dependencies have been similarly analyzed before it runs.
+	// Facts must be pointers.
+	//
+	// FactTypes establishes a "vertical" dependency between
+	// analysis passes (same analyzer, different packages).
+	FactTypes []Fact
+}
+
+func (a *Analyzer) String() string { return a.Name }
+
+// A Pass provides information to the Run function that
+// applies a specific analyzer to a single Go package.
+//
+// It forms the interface between the analysis logic and the driver
+// program, and has both input and an output components.
+//
+// As in a compiler, one pass may depend on the result computed by another.
+//
+// The Run function should not call any of the Pass functions concurrently.
+type Pass struct {
+	Analyzer *Analyzer // the identity of the current analyzer
+
+	// syntax and type information
+	Fset         *token.FileSet // file position information; Run may add new files
+	Files        []*ast.File    // the abstract syntax tree of each file
+	OtherFiles   []string       // names of non-Go files of this package
+	IgnoredFiles []string       // names of ignored source files in this package
+	Pkg          *types.Package // type information about the package
+	TypesInfo    *types.Info    // type information about the syntax trees
+	TypesSizes   types.Sizes    // function for computing sizes of types
+	TypeErrors   []types.Error  // type errors (only if Analyzer.RunDespiteErrors)
+
+	Module *Module // the package's enclosing module (possibly nil in some drivers)
+
+	// Report reports a Diagnostic, a finding about a specific location
+	// in the analyzed source code such as a potential mistake.
+	// It may be called by the Run function.
+	Report func(Diagnostic)
+
+	// ResultOf provides the inputs to this analysis pass, which are
+	// the corresponding results of its prerequisite analyzers.
+	// The map keys are the elements of Analysis.Required,
+	// and the type of each corresponding value is the required
+	// analysis's ResultType.
+	ResultOf map[*Analyzer]any
+
+	// ReadFile returns the contents of the named file.
+	//
+	// The only valid file names are the elements of OtherFiles
+	// and IgnoredFiles, and names returned by
+	// Fset.File(f.FileStart).Name() for each f in Files.
+	//
+	// Analyzers must use this function (if provided) instead of
+	// accessing the file system directly. This allows a driver to
+	// provide a virtualized file tree (including, for example,
+	// unsaved editor buffers) and to track dependencies precisely
+	// to avoid unnecessary recomputation.
+	ReadFile func(filename string) ([]byte, error)
+
+	// -- facts --
+
+	// ImportObjectFact retrieves a fact associated with obj.
+	// Given a value ptr of type *T, where *T satisfies Fact,
+	// ImportObjectFact copies the value to *ptr.
+	//
+	// ImportObjectFact panics if called after the pass is complete.
+	// ImportObjectFact is not concurrency-safe.
+	ImportObjectFact func(obj types.Object, fact Fact) bool
+
+	// ImportPackageFact retrieves a fact associated with package pkg,
+	// which must be this package or one of its dependencies.
+	// See comments for ImportObjectFact.
+	ImportPackageFact func(pkg *types.Package, fact Fact) bool
+
+	// ExportObjectFact associates a fact of type *T with the obj,
+	// replacing any previous fact of that type.
+	//
+	// ExportObjectFact panics if it is called after the pass is
+	// complete, or if obj does not belong to the package being analyzed.
+	// ExportObjectFact is not concurrency-safe.
+	ExportObjectFact func(obj types.Object, fact Fact)
+
+	// ExportPackageFact associates a fact with the current package.
+	// See comments for ExportObjectFact.
+	ExportPackageFact func(fact Fact)
+
+	// AllPackageFacts returns a new slice containing all package
+	// facts of the analysis's FactTypes in unspecified order.
+	// See comments for AllObjectFacts.
+	AllPackageFacts func() []PackageFact
+
+	// AllObjectFacts returns a new slice containing all object
+	// facts of the analysis's FactTypes in unspecified order.
+	//
+	// The result includes all facts exported by packages
+	// whose symbols are referenced by the current package
+	// (by qualified identifiers or field/method selections).
+	// And it includes all facts exported from the current
+	// package by the current analysis pass.
+	AllObjectFacts func() []ObjectFact
+
+	/* Further fields may be added in future. */
+}
+
+// PackageFact is a package together with an associated fact.
+type PackageFact struct {
+	Package *types.Package
+	Fact    Fact
+}
+
+// ObjectFact is an object together with an associated fact.
+type ObjectFact struct {
+	Object types.Object
+	Fact   Fact
+}
+
+// Reportf is a helper function that reports a Diagnostic using the
+// specified position and formatted error message.
+func (pass *Pass) Reportf(pos token.Pos, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	pass.Report(Diagnostic{Pos: pos, Message: msg})
+}
+
+// The Range interface provides a range. It's equivalent to and satisfied by
+// ast.Node.
+type Range interface {
+	Pos() token.Pos // position of first character belonging to the node
+	End() token.Pos // position of first character immediately after the node
+}
+
+// ReportRangef is a helper function that reports a Diagnostic using the
+// range provided. ast.Node values can be passed in as the range because
+// they satisfy the Range interface.
+func (pass *Pass) ReportRangef(rng Range, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	pass.Report(Diagnostic{Pos: rng.Pos(), End: rng.End(), Message: msg})
+}
+
+func (pass *Pass) String() string {
+	return fmt.Sprintf("%s@%s", pass.Analyzer.Name, pass.Pkg.Path())
+}
+
+// A Fact is an intermediate fact produced during analysis.
+//
+// Each fact is associated with a named declaration (a types.Object) or
+// with a package as a whole. A single object or package may have
+// multiple associated facts, but only one of any particular fact type.
+//
+// A Fact represents a predicate such as "never returns", but does not
+// represent the subject of the predicate such as "function F" or "package P".
+//
+// Facts may be produced in one analysis pass and consumed by another
+// analysis pass even if these are in different address spaces.
+// If package P imports Q, all facts about Q produced during
+// analysis of that package will be available during later analysis of P.
+// Facts are analogous to type export data in a build system:
+// just as export data enables separate compilation of several passes,
+// facts enable "separate analysis".
+//
+// Each pass (a, p) starts with the set of facts produced by the
+// same analyzer a applied to the packages directly imported by p.
+// The analysis may add facts to the set, and they may be exported in turn.
+// An analysis's Run function may retrieve facts by calling
+// Pass.Import{Object,Package}Fact and update them using
+// Pass.Export{Object,Package}Fact.
+//
+// A fact is logically private to its Analysis. To pass values
+// between different analyzers, use the results mechanism;
+// see Analyzer.Requires, Analyzer.ResultType, and Pass.ResultOf.
+//
+// A Fact type must be a pointer.
+// Facts are encoded and decoded using encoding/gob.
+// A Fact may implement the GobEncoder/GobDecoder interfaces
+// to customize its encoding. Fact encoding should not fail.
+//
+// A Fact should not be modified once exported.
+type Fact interface {
+	AFact() // dummy method to avoid type errors
+}
+
+// A Module describes the module to which a package belongs.
+type Module struct {
+	Path      string       // module path
+	Version   string       // module version ("" if unknown, such as for workspace modules)
+	Replace   *Module      // replaced by this module
+	Time      *time.Time   // time version was created
+	Main      bool         // is this the main module?
+	Indirect  bool         // is this module only an indirect dependency of main module?
+	Dir       string       // directory holding files for this module, if any
+	GoMod     string       // path to go.mod file used when loading this module, if any
+	GoVersion string       // go version used in module (e.g. "go1.22.0")
+	Error     *ModuleError // error loading module
+}
+
+// ModuleError holds errors loading a module.
+type ModuleError struct {
+	Err string // the error itself
+}

--- a/vendor/golang.org/x/tools/go/analysis/checker/checker.go
+++ b/vendor/golang.org/x/tools/go/analysis/checker/checker.go
@@ -1,0 +1,653 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package checker provides an analysis driver based on the
+// [golang.org/x/tools/go/packages] representation of a set of
+// packages and all their dependencies, as produced by
+// [packages.Load].
+//
+// It is the core of multichecker (the multi-analyzer driver),
+// singlechecker (the single-analyzer driver often used to provide a
+// convenient command alongside each analyzer), and analysistest, the
+// test driver.
+//
+// By contrast, the 'go vet' command is based on unitchecker, an
+// analysis driver that uses separate analysis--analogous to separate
+// compilation--with file-based intermediate results. Like separate
+// compilation, it is more scalable, especially for incremental
+// analysis of large code bases. Commands based on multichecker and
+// singlechecker are capable of detecting when they are being invoked
+// by "go vet -vettool=exe" and instead dispatching to unitchecker.
+//
+// Programs built using this package will, in general, not be usable
+// in that way. This package is intended only for use in applications
+// that invoke the analysis driver as a subroutine, and need to insert
+// additional steps before or after the analysis.
+//
+// See the Example of how to build a complete analysis driver program.
+package checker
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"go/types"
+	"io"
+	"iter"
+	"log"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/internal"
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/internal/analysis/driverutil"
+)
+
+// Options specifies options that control the analysis driver.
+type Options struct {
+	// These options correspond to existing flags exposed by multichecker:
+	Sequential  bool      // disable parallelism
+	SanityCheck bool      // check fact encoding is ok and deterministic
+	FactLog     io.Writer // if non-nil, log each exported fact to it
+
+	// TODO(adonovan): expose ReadFile so that an Overlay specified
+	// in the [packages.Config] can be communicated via
+	// Pass.ReadFile to each Analyzer.
+	readFile driverutil.ReadFileFunc
+}
+
+// Graph holds the results of a round of analysis, including the graph
+// of requested actions (analyzers applied to packages) plus any
+// dependent actions that it was necessary to compute.
+type Graph struct {
+	// Roots contains the roots of the action graph.
+	// Each node (a, p) in the action graph represents the
+	// application of one analyzer a to one package p.
+	// (A node thus corresponds to one analysis.Pass instance.)
+	// Roots holds one action per element of the product
+	// of the analyzers × packages arguments to Analyze,
+	// in unspecified order.
+	//
+	// Each element of Action.Deps represents an edge in the
+	// action graph: a dependency from one action to another.
+	// An edge of the form (a, p) -> (a, p2) indicates that the
+	// analysis of package p requires information ("facts") from
+	// the same analyzer applied to one of p's dependencies, p2.
+	// An edge of the form (a, p) -> (a2, p) indicates that the
+	// analysis of package p requires information ("results")
+	// from a different analyzer a2 applied to the same package.
+	// These two kind of edges are called "vertical" and "horizontal",
+	// respectively.
+	Roots []*Action
+}
+
+// All returns an iterator over the action graph in depth-first postorder.
+//
+// Example:
+//
+//	for act := range graph.All() {
+//		...
+//	}
+func (g *Graph) All() iter.Seq[*Action] {
+	return func(yield func(*Action) bool) {
+		forEach(g.Roots, func(act *Action) error {
+			if !yield(act) {
+				return io.EOF // any error will do
+			}
+			return nil
+		}) // ignore error
+	}
+}
+
+// An Action represents one unit of analysis work by the driver: the
+// application of one analysis to one package. It provides the inputs
+// to and records the outputs of a single analysis.Pass.
+//
+// Actions form a DAG, both within a package (as different analyzers
+// are applied, either in sequence or parallel), and across packages
+// (as dependencies are analyzed).
+type Action struct {
+	Analyzer    *analysis.Analyzer
+	Package     *packages.Package
+	IsRoot      bool // whether this is a root node of the graph
+	Deps        []*Action
+	Result      any   // computed result of Analyzer.run, if any (and if IsRoot)
+	Err         error // error result of Analyzer.run
+	Diagnostics []analysis.Diagnostic
+	Duration    time.Duration // execution time of this step
+
+	opts         *Options
+	once         sync.Once
+	pass         *analysis.Pass
+	objectFacts  map[objectFactKey]analysis.Fact
+	packageFacts map[packageFactKey]analysis.Fact
+}
+
+func (act *Action) String() string {
+	return fmt.Sprintf("%s@%s", act.Analyzer, act.Package)
+}
+
+// Analyze runs the specified analyzers on the initial packages.
+//
+// The initial packages and all dependencies must have been loaded
+// using the [packages.LoadAllSyntax] flag, Analyze may need to run
+// some analyzer (those that consume and produce facts) on
+// dependencies too.
+//
+// On success, it returns a Graph of actions whose Roots hold one
+// item per (a, p) in the cross-product of analyzers and pkgs.
+//
+// If opts is nil, it is equivalent to new(Options).
+func Analyze(analyzers []*analysis.Analyzer, pkgs []*packages.Package, opts *Options) (*Graph, error) {
+	if opts == nil {
+		opts = new(Options)
+	}
+
+	if err := analysis.Validate(analyzers); err != nil {
+		return nil, err
+	}
+
+	// Construct the action graph.
+	//
+	// Each graph node (action) is one unit of analysis.
+	// Edges express package-to-package (vertical) dependencies,
+	// and analysis-to-analysis (horizontal) dependencies.
+	type key struct {
+		a   *analysis.Analyzer
+		pkg *packages.Package
+	}
+	actions := make(map[key]*Action)
+
+	var mkAction func(a *analysis.Analyzer, pkg *packages.Package) *Action
+	mkAction = func(a *analysis.Analyzer, pkg *packages.Package) *Action {
+		k := key{a, pkg}
+		act, ok := actions[k]
+		if !ok {
+			act = &Action{Analyzer: a, Package: pkg, opts: opts}
+
+			// Add a dependency on each required analyzers.
+			for _, req := range a.Requires {
+				act.Deps = append(act.Deps, mkAction(req, pkg))
+			}
+
+			// An analysis that consumes/produces facts
+			// must run on the package's dependencies too.
+			if len(a.FactTypes) > 0 {
+				paths := make([]string, 0, len(pkg.Imports))
+				for path := range pkg.Imports {
+					paths = append(paths, path)
+				}
+				sort.Strings(paths) // for determinism
+				for _, path := range paths {
+					dep := mkAction(a, pkg.Imports[path])
+					act.Deps = append(act.Deps, dep)
+				}
+			}
+
+			actions[k] = act
+		}
+		return act
+	}
+
+	// Build nodes for initial packages.
+	var roots []*Action
+	for _, a := range analyzers {
+		for _, pkg := range pkgs {
+			root := mkAction(a, pkg)
+			root.IsRoot = true
+			roots = append(roots, root)
+		}
+	}
+
+	// Execute the graph in parallel.
+	execAll(roots)
+
+	// Ensure that only root Results are visible to caller.
+	// (The others are considered temporary intermediaries.)
+	// TODO(adonovan): opt: clear them earlier, so we can
+	// release large data structures like SSA sooner.
+	for _, act := range actions {
+		if !act.IsRoot {
+			act.Result = nil
+		}
+	}
+
+	return &Graph{Roots: roots}, nil
+}
+
+func init() {
+	// Allow analysistest to access Action.pass,
+	// for the legacy analysistest.Result data type,
+	// and for internal/checker.ApplyFixes to access pass.ReadFile.
+	internal.ActionPass = func(x any) *analysis.Pass { return x.(*Action).pass }
+}
+
+type objectFactKey struct {
+	obj types.Object
+	typ reflect.Type
+}
+
+type packageFactKey struct {
+	pkg *types.Package
+	typ reflect.Type
+}
+
+func execAll(actions []*Action) {
+	var wg sync.WaitGroup
+	for _, act := range actions {
+		wg.Add(1)
+		work := func(act *Action) {
+			act.exec()
+			wg.Done()
+		}
+		if act.opts.Sequential {
+			work(act)
+		} else {
+			go work(act)
+		}
+	}
+	wg.Wait()
+}
+
+func (act *Action) exec() { act.once.Do(act.execOnce) }
+
+func (act *Action) execOnce() {
+	// Analyze dependencies.
+	execAll(act.Deps)
+
+	// Record time spent in this node but not its dependencies.
+	// In parallel mode, due to GC/scheduler contention, the
+	// time is 5x higher than in sequential mode, even with a
+	// semaphore limiting the number of threads here.
+	// So use -debug=tp.
+	t0 := time.Now()
+	defer func() { act.Duration = time.Since(t0) }()
+
+	// Report an error if any dependency failed.
+	var failed []string
+	for _, dep := range act.Deps {
+		if dep.Err != nil {
+			failed = append(failed, dep.String())
+		}
+	}
+	if failed != nil {
+		sort.Strings(failed)
+		act.Err = fmt.Errorf("failed prerequisites: %s", strings.Join(failed, ", "))
+		return
+	}
+
+	// Plumb the output values of the dependencies
+	// into the inputs of this action.  Also facts.
+	inputs := make(map[*analysis.Analyzer]any)
+	act.objectFacts = make(map[objectFactKey]analysis.Fact)
+	act.packageFacts = make(map[packageFactKey]analysis.Fact)
+	for _, dep := range act.Deps {
+		if dep.Package == act.Package {
+			// Same package, different analysis (horizontal edge):
+			// in-memory outputs of prerequisite analyzers
+			// become inputs to this analysis pass.
+			inputs[dep.Analyzer] = dep.Result
+		} else if dep.Analyzer == act.Analyzer { // (always true)
+			// Same analysis, different package (vertical edge):
+			// serialized facts produced by prerequisite analysis
+			// become available to this analysis pass.
+			inheritFacts(act, dep)
+		}
+	}
+
+	// Quick (nonexhaustive) check that the correct go/packages mode bits were used.
+	// (If there were errors, all bets are off.)
+	if pkg := act.Package; pkg.Errors == nil {
+		if pkg.Name == "" || pkg.PkgPath == "" || pkg.Types == nil || pkg.Fset == nil || pkg.TypesSizes == nil {
+			panic("packages must be loaded with packages.LoadSyntax mode")
+		}
+	}
+
+	module := &analysis.Module{} // possibly empty (non nil) in go/analysis drivers.
+	if mod := act.Package.Module; mod != nil {
+		module = analysisModuleFromPackagesModule(mod)
+	}
+
+	// Run the analysis.
+	pass := &analysis.Pass{
+		Analyzer:     act.Analyzer,
+		Fset:         act.Package.Fset,
+		Files:        act.Package.Syntax,
+		OtherFiles:   act.Package.OtherFiles,
+		IgnoredFiles: act.Package.IgnoredFiles,
+		Pkg:          act.Package.Types,
+		TypesInfo:    act.Package.TypesInfo,
+		TypesSizes:   act.Package.TypesSizes,
+		TypeErrors:   act.Package.TypeErrors,
+		Module:       module,
+
+		ResultOf: inputs,
+		Report: func(d analysis.Diagnostic) {
+			// Assert that SuggestedFixes are well formed.
+			if err := driverutil.ValidateFixes(act.Package.Fset, act.Analyzer, d.SuggestedFixes); err != nil {
+				panic(err)
+			}
+			act.Diagnostics = append(act.Diagnostics, d)
+		},
+		ImportObjectFact:  act.ObjectFact,
+		ExportObjectFact:  act.exportObjectFact,
+		ImportPackageFact: act.PackageFact,
+		ExportPackageFact: act.exportPackageFact,
+		AllObjectFacts:    act.AllObjectFacts,
+		AllPackageFacts:   act.AllPackageFacts,
+	}
+	readFile := os.ReadFile
+	if act.opts.readFile != nil {
+		readFile = act.opts.readFile
+	}
+	pass.ReadFile = driverutil.CheckedReadFile(pass, readFile)
+	act.pass = pass
+
+	act.Result, act.Err = func() (any, error) {
+		if act.Package.IllTyped && !pass.Analyzer.RunDespiteErrors {
+			return nil, fmt.Errorf("analysis skipped due to errors in package")
+		}
+
+		result, err := pass.Analyzer.Run(pass)
+		if err != nil {
+			return nil, err
+		}
+
+		// correct result type?
+		if got, want := reflect.TypeOf(result), pass.Analyzer.ResultType; got != want {
+			return nil, fmt.Errorf(
+				"internal error: on package %s, analyzer %s returned a result of type %v, but declared ResultType %v",
+				pass.Pkg.Path(), pass.Analyzer, got, want)
+		}
+
+		// resolve diagnostic URLs
+		for i := range act.Diagnostics {
+			url, err := driverutil.ResolveURL(act.Analyzer, act.Diagnostics[i])
+			if err != nil {
+				return nil, err
+			}
+			act.Diagnostics[i].URL = url
+		}
+		return result, nil
+	}()
+
+	// Help detect (disallowed) calls after Run.
+	pass.ExportObjectFact = nil
+	pass.ExportPackageFact = nil
+}
+
+// inheritFacts populates act.facts with
+// those it obtains from its dependency, dep.
+func inheritFacts(act, dep *Action) {
+	for key, fact := range dep.objectFacts {
+		// Filter out facts related to objects
+		// that are irrelevant downstream
+		// (equivalently: not in the compiler export data).
+		if !exportedFrom(key.obj, dep.Package.Types) {
+			if false {
+				log.Printf("%v: discarding %T fact from %s for %s: %s", act, fact, dep, key.obj, fact)
+			}
+			continue
+		}
+
+		// Optionally serialize/deserialize fact
+		// to verify that it works across address spaces.
+		if act.opts.SanityCheck {
+			encodedFact, err := codeFact(fact)
+			if err != nil {
+				log.Panicf("internal error: encoding of %T fact failed in %v", fact, act)
+			}
+			fact = encodedFact
+		}
+
+		if false {
+			log.Printf("%v: inherited %T fact for %s: %s", act, fact, key.obj, fact)
+		}
+		act.objectFacts[key] = fact
+	}
+
+	for key, fact := range dep.packageFacts {
+		// TODO: filter out facts that belong to
+		// packages not mentioned in the export data
+		// to prevent side channels.
+		//
+		// The Pass.All{Object,Package}Facts accessors expose too much:
+		// all facts, of all types, for all dependencies in the action
+		// graph. Not only does the representation grow quadratically,
+		// but it violates the separate compilation paradigm, allowing
+		// analysis implementations to communicate with indirect
+		// dependencies that are not mentioned in the export data.
+		//
+		// It's not clear how to fix this short of a rather expensive
+		// filtering step after each action that enumerates all the
+		// objects that would appear in export data, and deletes
+		// facts associated with objects not in this set.
+
+		// Optionally serialize/deserialize fact
+		// to verify that it works across address spaces
+		// and is deterministic.
+		if act.opts.SanityCheck {
+			encodedFact, err := codeFact(fact)
+			if err != nil {
+				log.Panicf("internal error: encoding of %T fact failed in %v", fact, act)
+			}
+			fact = encodedFact
+		}
+
+		if false {
+			log.Printf("%v: inherited %T fact for %s: %s", act, fact, key.pkg.Path(), fact)
+		}
+		act.packageFacts[key] = fact
+	}
+}
+
+// codeFact encodes then decodes a fact,
+// just to exercise that logic.
+func codeFact(fact analysis.Fact) (analysis.Fact, error) {
+	// We encode facts one at a time.
+	// A real modular driver would emit all facts
+	// into one encoder to improve gob efficiency.
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(fact); err != nil {
+		return nil, err
+	}
+
+	// Encode it twice and assert that we get the same bits.
+	// This helps detect nondeterministic Gob encoding (e.g. of maps).
+	var buf2 bytes.Buffer
+	if err := gob.NewEncoder(&buf2).Encode(fact); err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(buf.Bytes(), buf2.Bytes()) {
+		return nil, fmt.Errorf("encoding of %T fact is nondeterministic", fact)
+	}
+
+	new := reflect.New(reflect.TypeOf(fact).Elem()).Interface().(analysis.Fact)
+	if err := gob.NewDecoder(&buf).Decode(new); err != nil {
+		return nil, err
+	}
+	return new, nil
+}
+
+// exportedFrom reports whether obj may be visible to a package that imports pkg.
+// This includes not just the exported members of pkg, but also unexported
+// constants, types, fields, and methods, perhaps belonging to other packages,
+// that find there way into the API.
+// This is an overapproximation of the more accurate approach used by
+// gc export data, which walks the type graph, but it's much simpler.
+//
+// TODO(adonovan): do more accurate filtering by walking the type graph.
+func exportedFrom(obj types.Object, pkg *types.Package) bool {
+	switch obj := obj.(type) {
+	case *types.Func:
+		return obj.Exported() && obj.Pkg() == pkg ||
+			obj.Signature().Recv() != nil
+	case *types.Var:
+		if obj.IsField() {
+			return true
+		}
+		// we can't filter more aggressively than this because we need
+		// to consider function parameters exported, but have no way
+		// of telling apart function parameters from local variables.
+		return obj.Pkg() == pkg
+	case *types.TypeName, *types.Const:
+		return true
+	}
+	return false // Nil, Builtin, Label, or PkgName
+}
+
+// ObjectFact retrieves a fact associated with obj,
+// and returns true if one was found.
+// Given a value ptr of type *T, where *T satisfies Fact,
+// ObjectFact copies the value to *ptr.
+//
+// See documentation at ImportObjectFact field of [analysis.Pass].
+func (act *Action) ObjectFact(obj types.Object, ptr analysis.Fact) bool {
+	if obj == nil {
+		panic("nil object")
+	}
+	key := objectFactKey{obj, factType(ptr)}
+	if v, ok := act.objectFacts[key]; ok {
+		reflect.ValueOf(ptr).Elem().Set(reflect.ValueOf(v).Elem())
+		return true
+	}
+	return false
+}
+
+// exportObjectFact implements Pass.ExportObjectFact.
+func (act *Action) exportObjectFact(obj types.Object, fact analysis.Fact) {
+	if act.pass.ExportObjectFact == nil {
+		log.Panicf("%s: Pass.ExportObjectFact(%s, %T) called after Run", act, obj, fact)
+	}
+
+	if obj.Pkg() != act.Package.Types {
+		log.Panicf("internal error: in analysis %s of package %s: Fact.Set(%s, %T): can't set facts on objects belonging another package",
+			act.Analyzer, act.Package, obj, fact)
+	}
+
+	key := objectFactKey{obj, factType(fact)}
+	act.objectFacts[key] = fact // clobber any existing entry
+	if log := act.opts.FactLog; log != nil {
+		objstr := types.ObjectString(obj, (*types.Package).Name)
+		fmt.Fprintf(log, "%s: object %s has fact %s\n",
+			act.Package.Fset.Position(obj.Pos()), objstr, fact)
+	}
+}
+
+// AllObjectFacts returns a new slice containing all object facts of
+// the analysis's FactTypes in unspecified order.
+//
+// See documentation at AllObjectFacts field of [analysis.Pass].
+func (act *Action) AllObjectFacts() []analysis.ObjectFact {
+	facts := make([]analysis.ObjectFact, 0, len(act.objectFacts))
+	for k, fact := range act.objectFacts {
+		facts = append(facts, analysis.ObjectFact{Object: k.obj, Fact: fact})
+	}
+	return facts
+}
+
+// PackageFact retrieves a fact associated with package pkg,
+// which must be this package or one of its dependencies.
+//
+// See documentation at ImportObjectFact field of [analysis.Pass].
+func (act *Action) PackageFact(pkg *types.Package, ptr analysis.Fact) bool {
+	if pkg == nil {
+		panic("nil package")
+	}
+	key := packageFactKey{pkg, factType(ptr)}
+	if v, ok := act.packageFacts[key]; ok {
+		reflect.ValueOf(ptr).Elem().Set(reflect.ValueOf(v).Elem())
+		return true
+	}
+	return false
+}
+
+// exportPackageFact implements Pass.ExportPackageFact.
+func (act *Action) exportPackageFact(fact analysis.Fact) {
+	if act.pass.ExportPackageFact == nil {
+		log.Panicf("%s: Pass.ExportPackageFact(%T) called after Run", act, fact)
+	}
+
+	key := packageFactKey{act.pass.Pkg, factType(fact)}
+	act.packageFacts[key] = fact // clobber any existing entry
+	if log := act.opts.FactLog; log != nil {
+		fmt.Fprintf(log, "%s: package %s has fact %s\n",
+			act.Package.Fset.Position(act.pass.Files[0].Pos()), act.pass.Pkg.Path(), fact)
+	}
+}
+
+func factType(fact analysis.Fact) reflect.Type {
+	t := reflect.TypeOf(fact)
+	if t.Kind() != reflect.Pointer {
+		log.Fatalf("invalid Fact type: got %T, want pointer", fact)
+	}
+	return t
+}
+
+// AllPackageFacts returns a new slice containing all package
+// facts of the analysis's FactTypes in unspecified order.
+//
+// See documentation at AllPackageFacts field of [analysis.Pass].
+func (act *Action) AllPackageFacts() []analysis.PackageFact {
+	facts := make([]analysis.PackageFact, 0, len(act.packageFacts))
+	for k, fact := range act.packageFacts {
+		facts = append(facts, analysis.PackageFact{Package: k.pkg, Fact: fact})
+	}
+	return facts
+}
+
+// forEach is a utility function for traversing the action graph. It
+// applies function f to each action in the graph reachable from
+// roots, in depth-first postorder. If any call to f returns an error,
+// the traversal is aborted and ForEach returns the error.
+func forEach(roots []*Action, f func(*Action) error) error {
+	seen := make(map[*Action]bool)
+	var visitAll func(actions []*Action) error
+	visitAll = func(actions []*Action) error {
+		for _, act := range actions {
+			if !seen[act] {
+				seen[act] = true
+				if err := visitAll(act.Deps); err != nil {
+					return err
+				}
+				if err := f(act); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	return visitAll(roots)
+}
+
+func analysisModuleFromPackagesModule(mod *packages.Module) *analysis.Module {
+	if mod == nil {
+		return nil
+	}
+
+	var modErr *analysis.ModuleError
+	if mod.Error != nil {
+		modErr = &analysis.ModuleError{
+			Err: mod.Error.Err,
+		}
+	}
+
+	return &analysis.Module{
+		Path:      mod.Path,
+		Version:   mod.Version,
+		Replace:   analysisModuleFromPackagesModule(mod.Replace),
+		Time:      mod.Time,
+		Main:      mod.Main,
+		Indirect:  mod.Indirect,
+		Dir:       mod.Dir,
+		GoMod:     mod.GoMod,
+		GoVersion: mod.GoVersion,
+		Error:     modErr,
+	}
+}

--- a/vendor/golang.org/x/tools/go/analysis/checker/print.go
+++ b/vendor/golang.org/x/tools/go/analysis/checker/print.go
@@ -1,0 +1,88 @@
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package checker
+
+// This file defines helpers for printing analysis results.
+// They should all be pure functions.
+
+import (
+	"bytes"
+	"fmt"
+	"go/token"
+	"io"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/internal/analysis/driverutil"
+)
+
+// PrintText emits diagnostics as plain text to w.
+//
+// If contextLines is nonnegative, it also prints the
+// offending line, plus that many lines of context
+// before and after the line.
+func (g *Graph) PrintText(w io.Writer, contextLines int) error {
+	return writeTextDiagnostics(w, g.Roots, contextLines)
+}
+
+func writeTextDiagnostics(w io.Writer, roots []*Action, contextLines int) error {
+	// De-duplicate diagnostics by position (not token.Pos) to
+	// avoid double-reporting in source files that belong to
+	// multiple packages, such as foo and foo.test.
+	// (We cannot assume that such repeated files were parsed
+	// only once and use syntax nodes as the key.)
+	type key struct {
+		pos token.Position
+		end token.Position
+		*analysis.Analyzer
+		message string
+	}
+	seen := make(map[key]bool)
+
+	// TODO(adonovan): opt: plumb errors back from PrintPlain and avoid buffer.
+	buf := new(bytes.Buffer)
+	forEach(roots, func(act *Action) error {
+		if act.Err != nil {
+			fmt.Fprintf(w, "%s: %v\n", act.Analyzer.Name, act.Err)
+		} else if act.IsRoot {
+			for _, diag := range act.Diagnostics {
+				// We don't display Analyzer.Name/diag.Category
+				// as most users don't care.
+
+				posn := act.Package.Fset.Position(diag.Pos)
+				end := act.Package.Fset.Position(diag.End)
+				k := key{posn, end, act.Analyzer, diag.Message}
+				if seen[k] {
+					continue // duplicate
+				}
+				seen[k] = true
+
+				driverutil.PrintPlain(buf, act.Package.Fset, contextLines, diag)
+			}
+		}
+		return nil
+	})
+	_, err := w.Write(buf.Bytes())
+	return err
+}
+
+// PrintJSON emits diagnostics in JSON form to w.
+// Diagnostics are shown only for the root nodes,
+// but errors (if any) are shown for all dependencies.
+func (g *Graph) PrintJSON(w io.Writer) error {
+	return writeJSONDiagnostics(w, g.Roots)
+}
+
+func writeJSONDiagnostics(w io.Writer, roots []*Action) error {
+	tree := make(driverutil.JSONTree)
+	forEach(roots, func(act *Action) error {
+		var diags []analysis.Diagnostic
+		if act.IsRoot {
+			diags = act.Diagnostics
+		}
+		tree.Add(act.Package.Fset, act.Package.ID, act.Analyzer.Name, diags, act.Err)
+		return nil
+	})
+	return tree.Print(w)
+}

--- a/vendor/golang.org/x/tools/go/analysis/diagnostic.go
+++ b/vendor/golang.org/x/tools/go/analysis/diagnostic.go
@@ -1,0 +1,88 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package analysis
+
+import "go/token"
+
+// A Diagnostic is a message associated with a source location or range.
+//
+// An Analyzer may return a variety of diagnostics; the optional Category,
+// which should be a constant, may be used to classify them.
+// It is primarily intended to make it easy to look up documentation.
+//
+// All Pos values are interpreted relative to Pass.Fset. If End is
+// provided, the diagnostic is specified to apply to the range between
+// Pos and End.
+type Diagnostic struct {
+	Pos      token.Pos
+	End      token.Pos // optional
+	Category string    // optional
+	Message  string
+
+	// URL is the optional location of a web page that provides
+	// additional documentation for this diagnostic.
+	//
+	// If URL is empty but a Category is specified, then the
+	// Analysis driver should treat the URL as "#"+Category.
+	//
+	// The URL may be relative. If so, the base URL is that of the
+	// Analyzer that produced the diagnostic;
+	// see https://pkg.go.dev/net/url#URL.ResolveReference.
+	URL string
+
+	// SuggestedFixes is an optional list of fixes to address the
+	// problem described by the diagnostic. Each one represents an
+	// alternative strategy, and should have a distinct and
+	// descriptive message; at most one may be applied.
+	//
+	// Fixes for different diagnostics should be treated as
+	// independent changes to the same baseline file state,
+	// analogous to a set of git commits all with the same parent.
+	// Combining fixes requires resolving any conflicts that
+	// arise, analogous to a git merge.
+	// Any conflicts that remain may be dealt with, depending on
+	// the tool, by discarding fixes, consulting the user, or
+	// aborting the operation.
+	SuggestedFixes []SuggestedFix
+
+	// Related contains optional secondary positions and messages
+	// related to the primary diagnostic.
+	Related []RelatedInformation
+}
+
+// RelatedInformation contains information related to a diagnostic.
+// For example, a diagnostic that flags duplicated declarations of a
+// variable may include one RelatedInformation per existing
+// declaration.
+type RelatedInformation struct {
+	Pos     token.Pos
+	End     token.Pos // optional
+	Message string
+}
+
+// A SuggestedFix is a code change associated with a Diagnostic that a
+// user can choose to apply to their code. Usually the SuggestedFix is
+// meant to fix the issue flagged by the diagnostic.
+//
+// The TextEdits must not overlap, nor contain edits for other
+// packages. Edits need not be totally ordered, but the order
+// determines how insertions at the same point will be applied.
+type SuggestedFix struct {
+	// A verb phrase describing the fix, to be shown to
+	// a user trying to decide whether to accept it.
+	//
+	// Example: "Remove the surplus argument"
+	Message   string
+	TextEdits []TextEdit
+}
+
+// A TextEdit represents the replacement of the code between Pos and End with the new text.
+// Each TextEdit should apply to a single file. End should not be earlier in the file than Pos.
+type TextEdit struct {
+	// For a pure insertion, End can either be set to Pos or token.NoPos.
+	Pos     token.Pos
+	End     token.Pos
+	NewText []byte
+}

--- a/vendor/golang.org/x/tools/go/analysis/doc.go
+++ b/vendor/golang.org/x/tools/go/analysis/doc.go
@@ -1,0 +1,317 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Package analysis defines the interface between a modular static
+analysis and an analysis driver program.
+
+# Background
+
+A static analysis is a function that inspects a package of Go code and
+reports a set of diagnostics (typically mistakes in the code), and
+perhaps produces other results as well, such as suggested refactorings
+or other facts. An analysis that reports mistakes is informally called a
+"checker". For example, the printf checker reports mistakes in
+fmt.Printf format strings.
+
+A "modular" analysis is one that inspects one package at a time but can
+save information from a lower-level package and use it when inspecting a
+higher-level package, analogous to separate compilation in a toolchain.
+The printf checker is modular: when it discovers that a function such as
+log.Fatalf delegates to fmt.Printf, it records this fact, and checks
+calls to that function too, including calls made from another package.
+
+By implementing a common interface, checkers from a variety of sources
+can be easily selected, incorporated, and reused in a wide range of
+driver programs including command-line tools (such as vet), text editors and
+IDEs, build and test systems (such as go build, Bazel, or Buck), test
+frameworks, code review tools, code-base indexers (such as SourceGraph),
+documentation viewers (such as godoc), batch pipelines for large code
+bases, and so on.
+
+# Analyzer
+
+The primary type in the API is [Analyzer]. An Analyzer statically
+describes an analysis function: its name, documentation, flags,
+relationship to other analyzers, and of course, its logic.
+
+To define an analysis, a user declares a (logically constant) variable
+of type Analyzer. Here is a typical example from one of the analyzers in
+the go/analysis/passes/ subdirectory:
+
+	package unusedresult
+
+	var Analyzer = &analysis.Analyzer{
+		Name: "unusedresult",
+		Doc:  "check for unused results of calls to some functions",
+		Run:  run,
+		...
+	}
+
+	func run(pass *analysis.Pass) (interface{}, error) {
+		...
+	}
+
+An analysis driver is a program such as vet that runs a set of
+analyses and prints the diagnostics that they report.
+The driver program must import the list of Analyzers it needs.
+Typically each Analyzer resides in a separate package.
+To add a new Analyzer to an existing driver, add another item to the list:
+
+	import ( "unusedresult"; "nilness"; "printf" )
+
+	var analyses = []*analysis.Analyzer{
+		unusedresult.Analyzer,
+		nilness.Analyzer,
+		printf.Analyzer,
+	}
+
+A driver may use the name, flags, and documentation to provide on-line
+help that describes the analyses it performs.
+The doc comment contains a brief one-line summary,
+optionally followed by paragraphs of explanation.
+
+The [Analyzer] type has more fields besides those shown above:
+
+	type Analyzer struct {
+		Name             string
+		Doc              string
+		Flags            flag.FlagSet
+		Run              func(*Pass) (interface{}, error)
+		RunDespiteErrors bool
+		ResultType       reflect.Type
+		Requires         []*Analyzer
+		FactTypes        []Fact
+	}
+
+The Flags field declares a set of named (global) flag variables that
+control analysis behavior. Unlike vet, analysis flags are not declared
+directly in the command line FlagSet; it is up to the driver to set the
+flag variables. A driver for a single analysis, a, might expose its flag
+f directly on the command line as -f, whereas a driver for multiple
+analyses might prefix the flag name by the analysis name (-a.f) to avoid
+ambiguity. An IDE might expose the flags through a graphical interface,
+and a batch pipeline might configure them from a config file.
+See the "findcall" analyzer for an example of flags in action.
+
+The RunDespiteErrors flag indicates whether the analysis is equipped to
+handle ill-typed code. If not, the driver will skip the analysis if
+there were parse or type errors.
+The optional ResultType field specifies the type of the result value
+computed by this analysis and made available to other analyses.
+The Requires field specifies a list of analyses upon which
+this one depends and whose results it may access, and it constrains the
+order in which a driver may run analyses.
+The FactTypes field is discussed in the section on Modularity.
+The analysis package provides a Validate function to perform basic
+sanity checks on an Analyzer, such as that its Requires graph is
+acyclic, its fact and result types are unique, and so on.
+
+Finally, the Run field contains a function to be called by the driver to
+execute the analysis on a single package. The driver passes it an
+instance of the Pass type.
+
+# Pass
+
+A [Pass] describes a single unit of work: the application of a particular
+Analyzer to a particular package of Go code.
+The Pass provides information to the Analyzer's Run function about the
+package being analyzed, and provides operations to the Run function for
+reporting diagnostics and other information back to the driver.
+
+	type Pass struct {
+		Fset         *token.FileSet
+		Files        []*ast.File
+		OtherFiles   []string
+		IgnoredFiles []string
+		Pkg          *types.Package
+		TypesInfo    *types.Info
+		ResultOf     map[*Analyzer]interface{}
+		Report       func(Diagnostic)
+		...
+	}
+
+The Fset, Files, Pkg, and TypesInfo fields provide the syntax trees,
+type information, and source positions for a single package of Go code.
+
+The OtherFiles field provides the names of non-Go
+files such as assembly that are part of this package.
+Similarly, the IgnoredFiles field provides the names of Go and non-Go
+source files that are not part of this package with the current build
+configuration but may be part of other build configurations.
+The contents of these files may be read using Pass.ReadFile;
+see the "asmdecl" or "buildtags" analyzers for examples of loading
+non-Go files and reporting diagnostics against them.
+
+The ResultOf field provides the results computed by the analyzers
+required by this one, as expressed in its Analyzer.Requires field. The
+driver runs the required analyzers first and makes their results
+available in this map. Each Analyzer must return a value of the type
+described in its Analyzer.ResultType field.
+For example, the "ctrlflow" analyzer returns a *ctrlflow.CFGs, which
+provides a control-flow graph for each function in the package (see
+golang.org/x/tools/go/cfg); the "inspect" analyzer returns a value that
+enables other Analyzers to traverse the syntax trees of the package more
+efficiently; and the "buildssa" analyzer constructs an SSA-form
+intermediate representation.
+Each of these Analyzers extends the capabilities of later Analyzers
+without adding a dependency to the core API, so an analysis tool pays
+only for the extensions it needs.
+
+The Report function emits a diagnostic, a message associated with a
+source position. For most analyses, diagnostics are their primary
+result.
+For convenience, Pass provides a helper method, Reportf, to report a new
+diagnostic by formatting a string.
+Diagnostic is defined as:
+
+	type Diagnostic struct {
+		Pos      token.Pos
+		Category string // optional
+		Message  string
+	}
+
+The optional Category field is a short identifier that classifies the
+kind of message when an analysis produces several kinds of diagnostic.
+
+The [Diagnostic] struct does not have a field to indicate its severity
+because opinions about the relative importance of Analyzers and their
+diagnostics vary widely among users. The design of this framework does
+not hold each Analyzer responsible for identifying the severity of its
+diagnostics. Instead, we expect that drivers will allow the user to
+customize the filtering and prioritization of diagnostics based on the
+producing Analyzer and optional Category, according to the user's
+preferences.
+
+Most Analyzers inspect typed Go syntax trees, but a few, such as asmdecl
+and buildtag, inspect the raw text of Go source files or even non-Go
+files such as assembly. To report a diagnostic against a line of a
+raw text file, use the following sequence:
+
+	content, err := pass.ReadFile(filename)
+	if err != nil { ... }
+	tf := fset.AddFile(filename, -1, len(content))
+	tf.SetLinesForContent(content)
+	...
+	pass.Reportf(tf.LineStart(line), "oops")
+
+# Modular analysis with Facts
+
+To improve efficiency and scalability, large programs are routinely
+built using separate compilation: units of the program are compiled
+separately, and recompiled only when one of their dependencies changes;
+independent modules may be compiled in parallel. The same technique may
+be applied to static analyses, for the same benefits. Such analyses are
+described as "modular".
+
+A compiler’s type checker is an example of a modular static analysis.
+Many other checkers we would like to apply to Go programs can be
+understood as alternative or non-standard type systems. For example,
+vet's printf checker infers whether a function has the "printf wrapper"
+type, and it applies stricter checks to calls of such functions. In
+addition, it records which functions are printf wrappers for use by
+later analysis passes to identify other printf wrappers by induction.
+A result such as “f is a printf wrapper” that is not interesting by
+itself but serves as a stepping stone to an interesting result (such as
+a diagnostic) is called a [Fact].
+
+The analysis API allows an analysis to define new types of facts, to
+associate facts of these types with objects (named entities) declared
+within the current package, or with the package as a whole, and to query
+for an existing fact of a given type associated with an object or
+package.
+
+An Analyzer that uses facts must declare their types:
+
+	var Analyzer = &analysis.Analyzer{
+		Name:      "printf",
+		FactTypes: []analysis.Fact{new(isWrapper)},
+		...
+	}
+
+	type isWrapper struct{} // => *types.Func f “is a printf wrapper”
+
+The driver program ensures that facts for a pass’s dependencies are
+generated before analyzing the package and is responsible for propagating
+facts from one package to another, possibly across address spaces.
+Consequently, Facts must be serializable. The API requires that drivers
+use the gob encoding, an efficient, robust, self-describing binary
+protocol. A fact type may implement the GobEncoder/GobDecoder interfaces
+if the default encoding is unsuitable. Facts should be stateless.
+Because serialized facts may appear within build outputs, the gob encoding
+of a fact must be deterministic, to avoid spurious cache misses in
+build systems that use content-addressable caches.
+The driver makes a single call to the gob encoder for all facts
+exported by a given analysis pass, so that the topology of
+shared data structures referenced by multiple facts is preserved.
+
+The Pass type has functions to import and export facts,
+associated either with an object or with a package:
+
+	type Pass struct {
+		...
+		ExportObjectFact func(types.Object, Fact)
+		ImportObjectFact func(types.Object, Fact) bool
+
+		ExportPackageFact func(fact Fact)
+		ImportPackageFact func(*types.Package, Fact) bool
+	}
+
+An Analyzer may only export facts associated with the current package or
+its objects, though it may import facts from any package or object that
+is an import dependency of the current package.
+
+Conceptually, ExportObjectFact(obj, fact) inserts fact into a hidden map keyed by
+the pair (obj, TypeOf(fact)), and the ImportObjectFact function
+retrieves the entry from this map and copies its value into the variable
+pointed to by fact. This scheme assumes that the concrete type of fact
+is a pointer; this assumption is checked by the Validate function.
+See the "printf" analyzer for an example of object facts in action.
+
+Some driver implementations (such as those based on Bazel and Blaze) do
+not currently apply analyzers to packages of the standard library.
+Therefore, for best results, analyzer authors should not rely on
+analysis facts being available for standard packages.
+For example, although the printf checker is capable of deducing during
+analysis of the log package that log.Printf is a printf wrapper,
+this fact is built in to the analyzer so that it correctly checks
+calls to log.Printf even when run in a driver that does not apply
+it to standard packages. We would like to remove this limitation in future.
+
+# Testing an Analyzer
+
+The analysistest subpackage provides utilities for testing an Analyzer.
+In a few lines of code, it is possible to run an analyzer on a package
+of testdata files and check that it reported all the expected
+diagnostics and facts (and no more). Expectations are expressed using
+"// want ..." comments in the input code.
+
+# Standalone commands
+
+Analyzers are provided in the form of packages that a driver program is
+expected to import. The vet command imports a set of several analyzers,
+but users may wish to define their own analysis commands that perform
+additional checks. To simplify the task of creating an analysis command,
+either for a single analyzer or for a whole suite, we provide the
+singlechecker and multichecker subpackages.
+
+The singlechecker package provides the main function for a command that
+runs one analyzer. By convention, each analyzer such as
+go/analysis/passes/findcall should be accompanied by a singlechecker-based
+command such as go/analysis/passes/findcall/cmd/findcall, defined in its
+entirety as:
+
+	package main
+
+	import (
+		"golang.org/x/tools/go/analysis/passes/findcall"
+		"golang.org/x/tools/go/analysis/singlechecker"
+	)
+
+	func main() { singlechecker.Main(findcall.Analyzer) }
+
+A tool that provides multiple analyzers can use multichecker in a
+similar way, giving it the list of Analyzers.
+*/
+package analysis

--- a/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/flags.go
+++ b/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/flags.go
@@ -1,0 +1,310 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package analysisflags defines helpers for processing flags (-help,
+// -json, -fix, -diff, etc) common to unitchecker and
+// {single,multi}checker. It is not intended for broader use.
+package analysisflags
+
+import (
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strconv"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// flags common to all {single,multi,unit}checkers.
+var (
+	JSON    = false // -json
+	Context = -1    // -c=N: if N>0, display offending line plus N lines of context
+	Fix     bool    // -fix
+	Diff    bool    // -diff
+)
+
+// Parse creates a flag for each of the analyzer's flags,
+// including (in multi mode) a flag named after the analyzer,
+// parses the flags, then filters and returns the list of
+// analyzers enabled by flags.
+//
+// The result is intended to be passed to unitchecker.Run or checker.Run.
+// Use in unitchecker.Run will gob.Register all fact types for the returned
+// graph of analyzers but of course not the ones only reachable from
+// dropped analyzers. To avoid inconsistency about which gob types are
+// registered from run to run, Parse itself gob.Registers all the facts
+// only reachable from dropped analyzers.
+// This is not a particularly elegant API, but this is an internal package.
+func Parse(analyzers []*analysis.Analyzer, multi bool) []*analysis.Analyzer {
+	// Connect each analysis flag to the command line as -analysis.flag.
+	enabled := make(map[*analysis.Analyzer]*triState)
+	for _, a := range analyzers {
+		var prefix string
+
+		// Add -NAME flag to enable it.
+		if multi {
+			prefix = a.Name + "."
+
+			enable := new(triState)
+			enableUsage := fmt.Sprintf("enable %q analysis", a.Name)
+			flag.Var(enable, a.Name, enableUsage)
+			enabled[a] = enable
+		}
+
+		a.Flags.VisitAll(func(f *flag.Flag) {
+			if !multi && flag.Lookup(f.Name) != nil {
+				log.Printf("%s flag -%s would conflict with driver; skipping", a.Name, f.Name)
+				return
+			}
+
+			name := prefix + f.Name
+			flag.Var(f.Value, name, f.Usage)
+		})
+	}
+
+	// standard flags: -flags, -V.
+	printflags := flag.Bool("flags", false, "print analyzer flags in JSON")
+	addVersionFlag()
+
+	// flags common to all checkers
+	flag.BoolVar(&JSON, "json", JSON, "emit JSON output")
+	flag.IntVar(&Context, "c", Context, `display offending line with this many lines of context`)
+	flag.BoolVar(&Fix, "fix", false, "apply all suggested fixes")
+	flag.BoolVar(&Diff, "diff", false, "with -fix, don't update the files, but print a unified diff")
+
+	// Add shims for legacy vet flags to enable existing
+	// scripts that run vet to continue to work.
+	_ = flag.Bool("source", false, "no effect (deprecated)")
+	_ = flag.Bool("v", false, "no effect (deprecated)")
+	_ = flag.Bool("all", false, "no effect (deprecated)")
+	_ = flag.String("tags", "", "no effect (deprecated)")
+	for old, new := range vetLegacyFlags {
+		newFlag := flag.Lookup(new)
+		if newFlag != nil && flag.Lookup(old) == nil {
+			flag.Var(newFlag.Value, old, "deprecated alias for -"+new)
+		}
+	}
+
+	flag.Parse() // (ExitOnError)
+
+	// -flags: print flags so that go vet knows which ones are legitimate.
+	if *printflags {
+		printFlags()
+		os.Exit(0)
+	}
+
+	everything := expand(analyzers)
+
+	// If any -NAME flag is true,  run only those analyzers. Otherwise,
+	// if any -NAME flag is false, run all but those analyzers.
+	if multi {
+		var hasTrue, hasFalse bool
+		for _, ts := range enabled {
+			switch *ts {
+			case setTrue:
+				hasTrue = true
+			case setFalse:
+				hasFalse = true
+			}
+		}
+
+		var keep []*analysis.Analyzer
+		if hasTrue {
+			for _, a := range analyzers {
+				if *enabled[a] == setTrue {
+					keep = append(keep, a)
+				}
+			}
+			analyzers = keep
+		} else if hasFalse {
+			for _, a := range analyzers {
+				if *enabled[a] != setFalse {
+					keep = append(keep, a)
+				}
+			}
+			analyzers = keep
+		}
+	}
+
+	// Register fact types of skipped analyzers
+	// in case we encounter them in imported files.
+	kept := expand(analyzers)
+	for a := range everything {
+		if !kept[a] {
+			for _, f := range a.FactTypes {
+				gob.Register(f)
+			}
+		}
+	}
+
+	return analyzers
+}
+
+func expand(analyzers []*analysis.Analyzer) map[*analysis.Analyzer]bool {
+	seen := make(map[*analysis.Analyzer]bool)
+	var visitAll func([]*analysis.Analyzer)
+	visitAll = func(analyzers []*analysis.Analyzer) {
+		for _, a := range analyzers {
+			if !seen[a] {
+				seen[a] = true
+				visitAll(a.Requires)
+			}
+		}
+	}
+	visitAll(analyzers)
+	return seen
+}
+
+func printFlags() {
+	type jsonFlag struct {
+		Name  string
+		Bool  bool
+		Usage string
+	}
+	var flags []jsonFlag = nil
+	flag.VisitAll(func(f *flag.Flag) {
+		// Don't report {single,multi}checker debugging
+		// flags or fix as these have no effect on unitchecker
+		// (as invoked by 'go vet').
+		switch f.Name {
+		case "debug", "cpuprofile", "memprofile", "trace", "fix":
+			return
+		}
+
+		b, ok := f.Value.(interface{ IsBoolFlag() bool })
+		isBool := ok && b.IsBoolFlag()
+		flags = append(flags, jsonFlag{f.Name, isBool, f.Usage})
+	})
+	data, err := json.MarshalIndent(flags, "", "\t")
+	if err != nil {
+		log.Fatal(err)
+	}
+	os.Stdout.Write(data)
+}
+
+// addVersionFlag registers a -V flag that, if set,
+// prints the executable version and exits 0.
+//
+// If the -V flag already exists — for example, because it was already
+// registered by a call to cmd/internal/objabi.AddVersionFlag — then
+// addVersionFlag does nothing.
+func addVersionFlag() {
+	if flag.Lookup("V") == nil {
+		flag.Var(versionFlag{}, "V", "print version and exit")
+	}
+}
+
+// versionFlag minimally complies with the -V protocol required by "go vet".
+type versionFlag struct{}
+
+func (versionFlag) IsBoolFlag() bool { return true }
+func (versionFlag) Get() any         { return nil }
+func (versionFlag) String() string   { return "" }
+func (versionFlag) Set(s string) error {
+	if s != "full" {
+		log.Fatalf("unsupported flag value: -V=%s (use -V=full)", s)
+	}
+
+	// This replicates the minimal subset of
+	// cmd/internal/objabi.AddVersionFlag, which is private to the
+	// go tool yet forms part of our command-line interface.
+	// TODO(adonovan): clarify the contract.
+
+	// Print the tool version so the build system can track changes.
+	// Formats:
+	//   $progname version devel ... buildID=...
+	//   $progname version go1.9.1
+	progname, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(progname)
+	if err != nil {
+		log.Fatal(err)
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		log.Fatal(err)
+	}
+	f.Close()
+	fmt.Printf("%s version devel comments-go-here buildID=%02x\n",
+		progname, string(h.Sum(nil)))
+	os.Exit(0)
+	return nil
+}
+
+// A triState is a boolean that knows whether
+// it has been set to either true or false.
+// It is used to identify whether a flag appears;
+// the standard boolean flag cannot
+// distinguish missing from unset.
+// It also satisfies flag.Value.
+type triState int
+
+const (
+	unset triState = iota
+	setTrue
+	setFalse
+)
+
+// triState implements flag.Value, flag.Getter, and flag.boolFlag.
+// They work like boolean flags: we can say vet -printf as well as vet -printf=true
+func (ts *triState) Get() any {
+	return *ts == setTrue
+}
+
+func (ts *triState) Set(value string) error {
+	b, err := strconv.ParseBool(value)
+	if err != nil {
+		// This error message looks poor but package "flag" adds
+		// "invalid boolean value %q for -NAME: %s"
+		return fmt.Errorf("want true or false")
+	}
+	if b {
+		*ts = setTrue
+	} else {
+		*ts = setFalse
+	}
+	return nil
+}
+
+func (ts *triState) String() string {
+	switch *ts {
+	case unset:
+		return "true"
+	case setTrue:
+		return "true"
+	case setFalse:
+		return "false"
+	}
+	panic("not reached")
+}
+
+func (ts triState) IsBoolFlag() bool {
+	return true
+}
+
+// Legacy flag support
+
+// vetLegacyFlags maps flags used by legacy vet to their corresponding
+// new names. The old names will continue to work.
+var vetLegacyFlags = map[string]string{
+	// Analyzer name changes
+	"bool":       "bools",
+	"buildtags":  "buildtag",
+	"methods":    "stdmethods",
+	"rangeloops": "loopclosure",
+
+	// Analyzer flags
+	"compositewhitelist":  "composites.whitelist",
+	"printfuncs":          "printf.funcs",
+	"shadowstrict":        "shadow.strict",
+	"unusedfuncs":         "unusedresult.funcs",
+	"unusedstringmethods": "unusedresult.stringmethods",
+}

--- a/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/help.go
+++ b/vendor/golang.org/x/tools/go/analysis/internal/analysisflags/help.go
@@ -1,0 +1,112 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package analysisflags
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+const help = `PROGNAME is a tool for static analysis of Go programs.
+
+PROGNAME examines Go source code and reports diagnostics for
+suspicious constructs or opportunities for improvement.
+Diagnostics may include suggested fixes.
+
+An example of a suspicious construct is a Printf call whose arguments
+do not align with the format string. Analyzers may use heuristics that
+do not guarantee all reports are genuine problems, but can find
+mistakes not caught by the compiler.
+
+An example of an opportunity for improvement is a loop over
+strings.Split(doc, "\n"), which may be replaced by a loop over the
+strings.SplitSeq iterator, avoiding an array allocation.
+Diagnostics in such cases may report non-problems,
+but should carry fixes that may be safely applied.
+
+For analyzers of the first kind, use "go vet -vettool=PROGRAM"
+to run the tool and report diagnostics.
+
+For analyzers of the second kind, use "go fix -fixtool=PROGRAM"
+to run the tool and apply the fixes it suggests.
+`
+
+// Help implements the help subcommand for a multichecker or unitchecker
+// style command. The optional args specify the analyzers to describe.
+// Help calls log.Fatal if no such analyzer exists.
+func Help(progname string, analyzers []*analysis.Analyzer, args []string) {
+	// No args: show summary of all analyzers.
+	if len(args) == 0 {
+		fmt.Println(strings.ReplaceAll(help, "PROGNAME", progname))
+		fmt.Println("Registered analyzers:")
+		fmt.Println()
+		sort.Slice(analyzers, func(i, j int) bool {
+			return analyzers[i].Name < analyzers[j].Name
+		})
+		for _, a := range analyzers {
+			title := strings.Split(a.Doc, "\n\n")[0]
+			fmt.Printf("    %-12s %s\n", a.Name, title)
+		}
+		fmt.Println("\nBy default all analyzers are run.")
+		fmt.Println("To select specific analyzers, use the -NAME flag for each one,")
+		fmt.Println(" or -NAME=false to run all analyzers not explicitly disabled.")
+
+		// Show only the core command-line flags.
+		fmt.Println("\nCore flags:")
+		fmt.Println()
+		fs := flag.NewFlagSet("", flag.ExitOnError)
+		flag.VisitAll(func(f *flag.Flag) {
+			if !strings.Contains(f.Name, ".") {
+				fs.Var(f.Value, f.Name, f.Usage)
+			}
+		})
+		fs.SetOutput(os.Stdout)
+		fs.PrintDefaults()
+
+		fmt.Printf("\nTo see details and flags of a specific analyzer, run '%s help name'.\n", progname)
+
+		return
+	}
+
+	// Show help on specific analyzer(s).
+outer:
+	for _, arg := range args {
+		for _, a := range analyzers {
+			if a.Name == arg {
+				paras := strings.Split(a.Doc, "\n\n")
+				title := paras[0]
+				fmt.Printf("%s: %s\n", a.Name, title)
+
+				// Show only the flags relating to this analysis,
+				// properly prefixed.
+				first := true
+				fs := flag.NewFlagSet(a.Name, flag.ExitOnError)
+				a.Flags.VisitAll(func(f *flag.Flag) {
+					if first {
+						first = false
+						fmt.Println("\nAnalyzer flags:")
+						fmt.Println()
+					}
+					fs.Var(f.Value, a.Name+"."+f.Name, f.Usage)
+				})
+				fs.SetOutput(os.Stdout)
+				fs.PrintDefaults()
+
+				if len(paras) > 1 {
+					fmt.Printf("\n%s\n", strings.Join(paras[1:], "\n\n"))
+				}
+
+				continue outer
+			}
+		}
+		log.Fatalf("Analyzer %q not registered", arg)
+	}
+}

--- a/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go
+++ b/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go
@@ -1,0 +1,344 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal/checker defines various implementation helpers for
+// the singlechecker and multichecker packages, which provide the
+// complete main function for an analysis driver executable
+// based on go/packages.
+//
+// (Note: it is not used by the public 'checker' package, since the
+// latter provides a set of pure functions for use as building blocks.)
+package checker
+
+// TODO(adonovan): publish the JSON schema in go/analysis or analysisjson.
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"log"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"runtime/trace"
+	"sort"
+	"strings"
+	"time"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/checker"
+	"golang.org/x/tools/go/analysis/internal"
+	"golang.org/x/tools/go/analysis/internal/analysisflags"
+	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/internal/analysis/driverutil"
+)
+
+var (
+	// Debug is a set of single-letter flags:
+	//
+	//	f	show [f]acts as they are created
+	// 	p	disable [p]arallel execution of analyzers
+	//	s	do additional [s]anity checks on fact types and serialization
+	//	t	show [t]iming info (NB: use 'p' flag to avoid GC/scheduler noise)
+	//	v	show [v]erbose logging
+	//
+	Debug = ""
+
+	// Log files for optional performance tracing.
+	CPUProfile, MemProfile, Trace string
+
+	// IncludeTests indicates whether test files should be analyzed too.
+	IncludeTests = true
+)
+
+// RegisterFlags registers command-line flags used by the analysis driver.
+func RegisterFlags() {
+	// When adding flags here, remember to update
+	// the list of suppressed flags in analysisflags.
+
+	flag.StringVar(&Debug, "debug", Debug, `debug flags, any subset of "fpstv"`)
+
+	flag.StringVar(&CPUProfile, "cpuprofile", "", "write CPU profile to this file")
+	flag.StringVar(&MemProfile, "memprofile", "", "write memory profile to this file")
+	flag.StringVar(&Trace, "trace", "", "write trace log to this file")
+	flag.BoolVar(&IncludeTests, "test", IncludeTests, "indicates whether test files should be analyzed, too")
+}
+
+// Run loads the packages specified by args using go/packages,
+// then applies the specified analyzers to them.
+// Analysis flags must already have been set.
+// Analyzers must be valid according to [analysis.Validate].
+// It provides most of the logic for the main functions of both the
+// singlechecker and the multi-analysis commands.
+// It returns the appropriate exit code.
+//
+// TODO(adonovan): tests should not call this function directly.
+// Fiddling with global variables (flags such as [analysisflags.Fix])
+// is error-prone and hostile to parallelism. Instead, use unit tests
+// of the actual units (e.g. checker.Analyze) and integration tests
+// (e.g. TestScript) of whole executables.
+func Run(args []string, analyzers []*analysis.Analyzer) (exitcode int) {
+	// Instead of returning a code directly,
+	// call this function to monotonically increase the exit code.
+	// This allows us to keep going in the face of some errors
+	// without having to remember what code to return.
+	//
+	// TODO(adonovan): interpreting exit codes is like reading tea-leaves.
+	// Instead of wasting effort trying to encode a multidimensional result
+	// into 7 bits we should just emit structured JSON output, and
+	// an exit code of 0 or 1 for success or failure.
+	exitAtLeast := func(code int) {
+		exitcode = max(code, exitcode)
+	}
+
+	// Since analysisflags is linked in (for {single,multi}checker),
+	// the -v flag is registered for complex legacy reasons
+	// related to cmd/vet CLI.
+	// Treat it as an undocumented alias for -debug=v.
+	if v := flag.CommandLine.Lookup("v"); v != nil &&
+		v.Value.(flag.Getter).Get() == true &&
+		!strings.Contains(Debug, "v") {
+		Debug += "v"
+	}
+
+	if CPUProfile != "" {
+		f, err := os.Create(CPUProfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			log.Fatal(err)
+		}
+		// NB: profile won't be written in case of error.
+		defer pprof.StopCPUProfile()
+	}
+
+	if Trace != "" {
+		f, err := os.Create(Trace)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := trace.Start(f); err != nil {
+			log.Fatal(err)
+		}
+		// NB: trace log won't be written in case of error.
+		defer func() {
+			trace.Stop()
+			log.Printf("To view the trace, run:\n$ go tool trace view %s", Trace)
+		}()
+	}
+
+	if MemProfile != "" {
+		f, err := os.Create(MemProfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		// NB: memprofile won't be written in case of error.
+		defer func() {
+			runtime.GC() // get up-to-date statistics
+			if err := pprof.WriteHeapProfile(f); err != nil {
+				log.Fatalf("Writing memory profile: %v", err)
+			}
+			f.Close()
+		}()
+	}
+
+	// Load the packages.
+	if dbg('v') {
+		log.SetPrefix("")
+		log.SetFlags(log.Lmicroseconds) // display timing
+		log.Printf("load %s", args)
+	}
+
+	// Optimization: if the selected analyzers don't produce/consume
+	// facts, we need source only for the initial packages.
+	allSyntax := needFacts(analyzers)
+	initial, err := load(args, allSyntax)
+	if err != nil {
+		log.Print(err)
+		exitAtLeast(1)
+		return
+	}
+
+	// Print package and module errors regardless of RunDespiteErrors.
+	// Do not exit if there are errors, yet.
+	if n := packages.PrintErrors(initial); n > 0 {
+		exitAtLeast(1)
+	}
+
+	var factLog io.Writer
+	if dbg('f') {
+		factLog = os.Stderr
+	}
+
+	// Run the analysis.
+	opts := &checker.Options{
+		SanityCheck: dbg('s'),
+		Sequential:  dbg('p'),
+		FactLog:     factLog,
+	}
+	if dbg('v') {
+		log.Printf("building graph of analysis passes")
+	}
+	graph, err := checker.Analyze(analyzers, initial, opts)
+	if err != nil {
+		log.Print(err)
+		exitAtLeast(1)
+		return
+	}
+
+	// Don't print the diagnostics,
+	// but apply all fixes from the root actions.
+	if analysisflags.Fix {
+		fixActions := make([]driverutil.FixAction, len(graph.Roots))
+		for i, act := range graph.Roots {
+			if pass := internal.ActionPass(act); pass != nil {
+				fixActions[i] = driverutil.FixAction{
+					Name:         act.String(),
+					Pkg:          act.Package.Types,
+					Files:        act.Package.Syntax,
+					FileSet:      act.Package.Fset,
+					ReadFileFunc: pass.ReadFile,
+					Diagnostics:  act.Diagnostics,
+				}
+			}
+		}
+		write := func(filename string, content []byte) error {
+			return os.WriteFile(filename, content, 0644)
+		}
+		if err := driverutil.ApplyFixes(fixActions, write, analysisflags.Diff, dbg('v')); err != nil {
+			// Fail when applying fixes failed.
+			log.Print(err)
+			exitAtLeast(1)
+			return
+		}
+		// Don't proceed to print text/JSON,
+		// and don't report an error
+		// just because there were diagnostics.
+		return
+	}
+
+	// Print the results. If !RunDespiteErrors and there
+	// are errors in the packages, this will have 0 exit
+	// code. Otherwise, we prefer to return exit code
+	// indicating diagnostics.
+	exitAtLeast(printDiagnostics(graph))
+
+	return
+}
+
+// printDiagnostics prints diagnostics in text or JSON form
+// and returns the appropriate exit code.
+func printDiagnostics(graph *checker.Graph) (exitcode int) {
+	// Keep consistent with analogous logic in
+	// processResults in ../../unitchecker/unitchecker.go.
+
+	// Print the results.
+	// With -json, the exit code is always zero.
+	if analysisflags.JSON {
+		if err := graph.PrintJSON(os.Stdout); err != nil {
+			return 1
+		}
+	} else {
+		if err := graph.PrintText(os.Stderr, analysisflags.Context); err != nil {
+			return 1
+		}
+
+		// Compute the exit code.
+		var numErrors, rootDiags int
+		for act := range graph.All() {
+			if act.Err != nil {
+				numErrors++
+			} else if act.IsRoot {
+				rootDiags += len(act.Diagnostics)
+			}
+		}
+
+		if numErrors > 0 {
+			exitcode = 1 // analysis failed, at least partially
+		} else if rootDiags > 0 {
+			exitcode = 3 // successfully produced diagnostics
+		}
+	}
+
+	// Print timing info.
+	if dbg('t') {
+		if !dbg('p') {
+			log.Println("Warning: times are mostly GC/scheduler noise; use -debug=tp to disable parallelism")
+		}
+
+		var list []*checker.Action
+		var total time.Duration
+		for act := range graph.All() {
+			list = append(list, act)
+			total += act.Duration
+		}
+
+		// Print actions accounting for 90% of the total.
+		sort.Slice(list, func(i, j int) bool {
+			return list[i].Duration > list[j].Duration
+		})
+		var sum time.Duration
+		for _, act := range list {
+			fmt.Fprintf(os.Stderr, "%s\t%s\n", act.Duration, act)
+			sum += act.Duration
+			if sum >= total*9/10 {
+				break
+			}
+		}
+		if total > sum {
+			fmt.Fprintf(os.Stderr, "%s\tall others\n", total-sum)
+		}
+	}
+
+	return exitcode
+}
+
+// load loads the initial packages. Returns only top-level loading
+// errors. Does not consider errors in packages.
+func load(patterns []string, allSyntax bool) ([]*packages.Package, error) {
+	mode := packages.LoadSyntax
+	if allSyntax {
+		mode = packages.LoadAllSyntax
+	}
+	mode |= packages.NeedModule
+	conf := packages.Config{
+		Mode: mode,
+		// Ensure that child process inherits correct alias of PWD.
+		// (See discussion at Dir field of [exec.Command].)
+		// However, this currently breaks some tests.
+		// TODO(adonovan): Investigate.
+		//
+		// Dir:   os.Getenv("PWD"),
+		Tests: IncludeTests,
+	}
+	initial, err := packages.Load(&conf, patterns...)
+	if err == nil && len(initial) == 0 {
+		err = fmt.Errorf("%s matched no packages", strings.Join(patterns, " "))
+	}
+	return initial, err
+}
+
+// needFacts reports whether any analysis required by the specified set
+// needs facts.  If so, we must load the entire program from source.
+func needFacts(analyzers []*analysis.Analyzer) bool {
+	seen := make(map[*analysis.Analyzer]bool)
+	var q []*analysis.Analyzer // for BFS
+	q = append(q, analyzers...)
+	for len(q) > 0 {
+		a := q[0]
+		q = q[1:]
+		if !seen[a] {
+			seen[a] = true
+			if len(a.FactTypes) > 0 {
+				return true
+			}
+			q = append(q, a.Requires...)
+		}
+	}
+	return false
+}
+
+func dbg(b byte) bool { return strings.IndexByte(Debug, b) >= 0 }

--- a/vendor/golang.org/x/tools/go/analysis/internal/internal.go
+++ b/vendor/golang.org/x/tools/go/analysis/internal/internal.go
@@ -1,0 +1,15 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+import "golang.org/x/tools/go/analysis"
+
+// This function is set by the checker package to provide
+// backdoor access to the private Pass field
+// of the *checker.Action type, for use by analysistest.
+//
+// It may return nil, for example if the action was not
+// executed because of a failed dependent.
+var ActionPass func(action any) *analysis.Pass

--- a/vendor/golang.org/x/tools/go/analysis/singlechecker/singlechecker.go
+++ b/vendor/golang.org/x/tools/go/analysis/singlechecker/singlechecker.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singlechecker defines the main function for an analysis
+// driver with only a single analysis.
+// This package makes it easy for a provider of an analysis package to
+// also provide a standalone tool that runs just that analysis.
+//
+// For example, if example.org/findbadness is an analysis package,
+// all that is needed to define a standalone tool is a file,
+// example.org/findbadness/cmd/findbadness/main.go, containing:
+//
+//	// The findbadness command runs an analysis.
+//	package main
+//
+//	import (
+//		"example.org/findbadness"
+//		"golang.org/x/tools/go/analysis/singlechecker"
+//	)
+//
+//	func main() { singlechecker.Main(findbadness.Analyzer) }
+package singlechecker
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/internal/analysisflags"
+	"golang.org/x/tools/go/analysis/internal/checker"
+	"golang.org/x/tools/go/analysis/unitchecker"
+)
+
+// Main is the main function for a checker command for a single analysis.
+func Main(a *analysis.Analyzer) {
+	log.SetFlags(0)
+	log.SetPrefix(a.Name + ": ")
+
+	analyzers := []*analysis.Analyzer{a}
+
+	if err := analysis.Validate(analyzers); err != nil {
+		log.Fatal(err)
+	}
+
+	checker.RegisterFlags()
+
+	flag.Usage = func() {
+		paras := strings.Split(a.Doc, "\n\n")
+		fmt.Fprintf(os.Stderr, "%s: %s\n\n", a.Name, paras[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s [-flag] [package]\n\n", a.Name)
+		if len(paras) > 1 {
+			fmt.Fprintln(os.Stderr, strings.Join(paras[1:], "\n\n"))
+		}
+		fmt.Fprintln(os.Stderr, "\nFlags:")
+		flag.PrintDefaults()
+	}
+
+	analyzers = analysisflags.Parse(analyzers, false)
+
+	args := flag.Args()
+	if len(args) == 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	if len(args) == 1 && strings.HasSuffix(args[0], ".cfg") {
+		unitchecker.Run(args[0], analyzers)
+		panic("unreachable")
+	}
+
+	os.Exit(checker.Run(args, analyzers))
+}

--- a/vendor/golang.org/x/tools/go/analysis/unitchecker/unitchecker.go
+++ b/vendor/golang.org/x/tools/go/analysis/unitchecker/unitchecker.go
@@ -1,0 +1,551 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The unitchecker package defines the main function for an analysis
+// driver that analyzes a single compilation unit during a build.
+// It is invoked by a build system such as "go vet":
+//
+//	$ go vet -vettool=$(which vet)
+//
+// It supports the following command-line protocol:
+//
+//	-V=full         describe executable               (to the build tool)
+//	-flags          describe flags                    (to the build tool)
+//	foo.cfg         description of compilation unit (from the build tool)
+//
+// This package does not depend on go/packages.
+// If you need a standalone tool, use multichecker,
+// which supports this mode but can also load packages
+// from source using go/packages.
+package unitchecker
+
+// TODO(adonovan):
+// - with gccgo, go build does not build standard library,
+//   so we will not get to analyze it. Yet we must in order
+//   to create base facts for, say, the fmt package for the
+//   printf checker.
+
+import (
+	"archive/zip"
+	"encoding/gob"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/build"
+	"go/importer"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/internal/analysisflags"
+	"golang.org/x/tools/internal/analysis/driverutil"
+	"golang.org/x/tools/internal/facts"
+)
+
+// A Config describes a compilation unit to be analyzed.
+// It is provided to the tool in a JSON-encoded file
+// whose name ends with ".cfg".
+type Config struct {
+	ID                        string // e.g. "fmt [fmt.test]"
+	Compiler                  string // gc or gccgo, provided to MakeImporter
+	Dir                       string // (unused)
+	ImportPath                string // package path
+	GoVersion                 string // minimum required Go version, such as "go1.21.0"
+	GoFiles                   []string
+	NonGoFiles                []string
+	IgnoredFiles              []string
+	ModulePath                string            // Deprecated: redundant w.r.t. Module.Path in go1.27; remove after go1.28.
+	ModuleVersion             string            // Deprecated: redundant w.r.t. Module.Version in go1.27; remove after go1.28.
+	Module                    *analysis.Module  // module information, if any
+	ImportMap                 map[string]string // maps import path to package path
+	PackageFile               map[string]string // maps package path to file of type information
+	Standard                  map[string]bool   // package belongs to standard library
+	PackageVetx               map[string]string // maps package path to file of fact information
+	VetxOnly                  bool              // run analysis only for facts, not diagnostics
+	VetxOutput                string            // where to write file of fact information
+	Stdout                    string            // write stdout (e.g. JSON, unified diff) to this file
+	FixArchive                string            // write fixed files to this zip archive, if non-empty
+	SucceedOnTypecheckFailure bool              // obsolete awful hack; see #18395 and below
+}
+
+// Main is the main function of a vet-like analysis tool that must be
+// invoked by a build system to analyze a single package.
+//
+// The protocol required by 'go vet -vettool=...' is that the tool must support:
+//
+//	-flags          describe flags in JSON
+//	-V=full         describe executable for build caching
+//	foo.cfg         perform separate modular analyze on the single
+//	                unit described by a JSON config file foo.cfg.
+//	-fix		don't print each diagnostic, apply its first fix
+//	-diff		don't apply a fix, print the diff (requires -fix)
+//	-json		print diagnostics and fixes in JSON form
+func Main(analyzers ...*analysis.Analyzer) {
+	progname := filepath.Base(os.Args[0])
+	log.SetFlags(0)
+	log.SetPrefix(progname + ": ")
+
+	if err := analysis.Validate(analyzers); err != nil {
+		log.Fatal(err)
+	}
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `%[1]s is a tool for static analysis of Go programs.
+
+Usage of %[1]s:
+	%.16[1]s unit.cfg	# execute analysis specified by config file
+	%.16[1]s help    	# general help, including listing analyzers and flags
+	%.16[1]s help name	# help on specific analyzer and its flags
+`, progname)
+		os.Exit(1)
+	}
+
+	analyzers = analysisflags.Parse(analyzers, true)
+
+	args := flag.Args()
+	if len(args) == 0 {
+		flag.Usage()
+	}
+	if args[0] == "help" {
+		analysisflags.Help(progname, analyzers, args[1:])
+		os.Exit(0)
+	}
+	if len(args) != 1 || !strings.HasSuffix(args[0], ".cfg") {
+		log.Fatalf(`invoking "go tool %[1]s" directly is unsupported; use "go %[1]s"`, progname)
+	}
+	Run(args[0], analyzers)
+}
+
+// Run reads the *.cfg file, runs the analysis,
+// and calls os.Exit with an appropriate error code.
+// It assumes flags have already been set.
+func Run(configFile string, analyzers []*analysis.Analyzer) {
+	cfg, err := readConfig(configFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Redirect stdout to a file as requested.
+	if cfg.Stdout != "" {
+		f, err := os.Create(cfg.Stdout)
+		if err != nil {
+			log.Fatal(err)
+		}
+		os.Stdout = f
+	}
+
+	fset := token.NewFileSet()
+	results, err := run(fset, cfg, analyzers)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	code := 0
+
+	// In VetxOnly mode, the analysis is run only for facts.
+	if !cfg.VetxOnly {
+		code = processResults(fset, cfg.ID, cfg.FixArchive, results)
+	}
+
+	os.Exit(code)
+}
+
+func readConfig(filename string) (*Config, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	cfg := new(Config)
+	if err := json.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("cannot decode JSON config file %s: %v", filename, err)
+	}
+	if len(cfg.GoFiles) == 0 {
+		// The go command disallows packages with no files.
+		// The only exception is unsafe, but the go command
+		// doesn't call vet on it.
+		return nil, fmt.Errorf("package has no files: %s", cfg.ImportPath)
+	}
+	return cfg, nil
+}
+
+func processResults(fset *token.FileSet, id, fixArchive string, results []result) (exit int) {
+	if analysisflags.Fix {
+		// Don't print the diagnostics,
+		// but apply all fixes from the root actions.
+
+		// Convert results to form needed by ApplyFixes.
+		fixActions := make([]driverutil.FixAction, len(results))
+		for i, res := range results {
+			fixActions[i] = driverutil.FixAction{
+				Name:         res.a.Name,
+				Pkg:          res.pkg,
+				Files:        res.files,
+				FileSet:      fset,
+				ReadFileFunc: os.ReadFile, // TODO(adonovan): respect overlays
+				Diagnostics:  res.diagnostics,
+			}
+		}
+
+		// By default, fixes overwrite the original file.
+		// With the -diff flag, print the diffs to stdout.
+		// If "go fix" provides a fix archive, we write files
+		// into it so that mutations happen after the build.
+		write := func(filename string, content []byte) error {
+			return os.WriteFile(filename, content, 0644)
+		}
+		if fixArchive != "" {
+			f, err := os.Create(fixArchive)
+			if err != nil {
+				log.Fatalf("can't create -fix archive: %v", err)
+			}
+			zw := zip.NewWriter(f)
+			zw.SetComment(id) // ignore error
+			defer func() {
+				if err := zw.Close(); err != nil {
+					log.Fatalf("closing -fix archive zip writer: %v", err)
+				}
+				if err := f.Close(); err != nil {
+					log.Fatalf("closing -fix archive file: %v", err)
+				}
+			}()
+			write = func(filename string, content []byte) error {
+				f, err := zw.Create(filename)
+				if err != nil {
+					return err
+				}
+				_, err = f.Write(content)
+				return err
+			}
+		}
+
+		if err := driverutil.ApplyFixes(fixActions, write, analysisflags.Diff, false); err != nil {
+			// Fail when applying fixes failed.
+			log.Print(err)
+			exit = 1
+		}
+
+		// Don't proceed to print text/JSON,
+		// and don't report an error
+		// just because there were diagnostics.
+		return
+	}
+
+	// Keep consistent with analogous logic in
+	// printDiagnostics in ../internal/checker/checker.go.
+
+	if analysisflags.JSON {
+		// JSON output
+		tree := make(driverutil.JSONTree)
+		for _, res := range results {
+			tree.Add(fset, id, res.a.Name, res.diagnostics, res.err)
+		}
+		tree.Print(os.Stdout) // ignore error
+
+	} else {
+		// plain text
+		for _, res := range results {
+			if res.err != nil {
+				log.Println(res.err)
+				exit = 1
+			}
+		}
+		for _, res := range results {
+			for _, diag := range res.diagnostics {
+				driverutil.PrintPlain(os.Stderr, fset, analysisflags.Context, diag)
+				exit = 1
+			}
+		}
+	}
+
+	return
+}
+
+type factImporter = func(pkgPath string) ([]byte, error)
+
+// These four hook variables are a proof of concept of a future
+// parameterization of a unitchecker API that allows the client to
+// determine how and where facts and types are produced and consumed.
+// (Note that the eventual API will likely be quite different.)
+//
+// The defaults honor a Config in a manner compatible with 'go vet'.
+var (
+	makeTypesImporter = func(cfg *Config, fset *token.FileSet) types.Importer {
+		compilerImporter := importer.ForCompiler(fset, cfg.Compiler, func(path string) (io.ReadCloser, error) {
+			// path is a resolved package path, not an import path.
+			file, ok := cfg.PackageFile[path]
+			if !ok {
+				if cfg.Compiler == "gccgo" && cfg.Standard[path] {
+					return nil, nil // fall back to default gccgo lookup
+				}
+				return nil, fmt.Errorf("no package file for %q", path)
+			}
+			return os.Open(file)
+		})
+		return importerFunc(func(importPath string) (*types.Package, error) {
+			path, ok := cfg.ImportMap[importPath] // resolve vendoring, etc
+			if !ok {
+				return nil, fmt.Errorf("can't resolve import %q", path)
+			}
+			return compilerImporter.Import(path)
+		})
+	}
+
+	exportTypes = func(*Config, *token.FileSet, *types.Package) error {
+		// By default this is a no-op, because "go vet"
+		// makes the compiler produce type information.
+		return nil
+	}
+
+	makeFactImporter = func(cfg *Config) factImporter {
+		return func(pkgPath string) ([]byte, error) {
+			if vetx, ok := cfg.PackageVetx[pkgPath]; ok {
+				return os.ReadFile(vetx)
+			}
+			return nil, nil // no .vetx file, no facts
+		}
+	}
+
+	exportFacts = func(cfg *Config, data []byte) error {
+		return os.WriteFile(cfg.VetxOutput, data, 0666)
+	}
+)
+
+func run(fset *token.FileSet, cfg *Config, analyzers []*analysis.Analyzer) ([]result, error) {
+	// Load, parse, typecheck.
+	var files []*ast.File
+	for _, name := range cfg.GoFiles {
+		f, err := parser.ParseFile(fset, name, nil, parser.ParseComments)
+		if err != nil {
+			if cfg.SucceedOnTypecheckFailure {
+				// Silently succeed; let the compiler
+				// report parse errors.
+				err = nil
+			}
+			return nil, err
+		}
+		files = append(files, f)
+	}
+	tc := &types.Config{
+		Importer:  makeTypesImporter(cfg, fset),
+		Sizes:     types.SizesFor("gc", build.Default.GOARCH), // TODO(adonovan): use cfg.Compiler
+		GoVersion: cfg.GoVersion,
+	}
+	info := &types.Info{
+		Types:        make(map[ast.Expr]types.TypeAndValue),
+		Defs:         make(map[*ast.Ident]types.Object),
+		Uses:         make(map[*ast.Ident]types.Object),
+		Implicits:    make(map[ast.Node]types.Object),
+		Instances:    make(map[*ast.Ident]types.Instance),
+		Scopes:       make(map[ast.Node]*types.Scope),
+		Selections:   make(map[*ast.SelectorExpr]*types.Selection),
+		FileVersions: make(map[*ast.File]string),
+	}
+
+	pkg, err := tc.Check(cfg.ImportPath, fset, files, info)
+	if err != nil {
+		if cfg.SucceedOnTypecheckFailure {
+			// Silently succeed; let the compiler
+			// report type errors.
+			err = nil
+		}
+		return nil, err
+	}
+
+	// Register fact types with gob.
+	// In VetxOnly mode, analyzers are only for their facts,
+	// so we can skip any analysis that neither produces facts
+	// nor depends on any analysis that produces facts.
+	//
+	// TODO(adonovan): fix: the command (and logic!) here are backwards.
+	// It should say "...nor is required by any...". (Issue 443099)
+	//
+	// Also build a map to hold working state and result.
+	type action struct {
+		once        sync.Once
+		result      any
+		err         error
+		usesFacts   bool // (transitively uses)
+		diagnostics []analysis.Diagnostic
+	}
+	actions := make(map[*analysis.Analyzer]*action)
+	var registerFacts func(a *analysis.Analyzer) bool
+	registerFacts = func(a *analysis.Analyzer) bool {
+		act, ok := actions[a]
+		if !ok {
+			act = new(action)
+			var usesFacts bool
+			for _, f := range a.FactTypes {
+				usesFacts = true
+				gob.Register(f)
+			}
+			for _, req := range a.Requires {
+				if registerFacts(req) {
+					usesFacts = true
+				}
+			}
+			act.usesFacts = usesFacts
+			actions[a] = act
+		}
+		return act.usesFacts
+	}
+	var filtered []*analysis.Analyzer
+	for _, a := range analyzers {
+		if registerFacts(a) || !cfg.VetxOnly {
+			filtered = append(filtered, a)
+		}
+	}
+	analyzers = filtered
+
+	// Read facts from imported packages.
+	facts, err := facts.NewDecoder(pkg).Decode(makeFactImporter(cfg))
+	if err != nil {
+		return nil, err
+	}
+
+	// In parallel, execute the DAG of analyzers.
+	var exec func(a *analysis.Analyzer) *action
+	var execAll func(analyzers []*analysis.Analyzer)
+	exec = func(a *analysis.Analyzer) *action {
+		act := actions[a]
+		act.once.Do(func() {
+			execAll(a.Requires) // prefetch dependencies in parallel
+
+			// The inputs to this analysis are the
+			// results of its prerequisites.
+			inputs := make(map[*analysis.Analyzer]any)
+			var failed []string
+			for _, req := range a.Requires {
+				reqact := exec(req)
+				if reqact.err != nil {
+					failed = append(failed, req.String())
+					continue
+				}
+				inputs[req] = reqact.result
+			}
+
+			// Report an error if any dependency failed.
+			if failed != nil {
+				sort.Strings(failed)
+				act.err = fmt.Errorf("failed prerequisites: %s", strings.Join(failed, ", "))
+				return
+			}
+
+			factFilter := make(map[reflect.Type]bool)
+			for _, f := range a.FactTypes {
+				factFilter[reflect.TypeOf(f)] = true
+			}
+
+			module := cfg.Module
+			// cmd/go vet prior to go1.27 did not populate cfg.Module. Do our best.
+			if module == nil && cfg.ModulePath != "" {
+				module = &analysis.Module{
+					Path:      cfg.ModulePath,
+					Version:   cfg.ModuleVersion,
+					GoVersion: cfg.GoVersion,
+				}
+			}
+
+			pass := &analysis.Pass{
+				Analyzer:     a,
+				Fset:         fset,
+				Files:        files,
+				OtherFiles:   cfg.NonGoFiles,
+				IgnoredFiles: cfg.IgnoredFiles,
+				Pkg:          pkg,
+				TypesInfo:    info,
+				TypesSizes:   tc.Sizes,
+				TypeErrors:   nil, // unitchecker doesn't RunDespiteErrors
+				ResultOf:     inputs,
+				Report: func(d analysis.Diagnostic) {
+					// Unitchecker doesn't apply fixes, but it does report them in the JSON output.
+					if err := driverutil.ValidateFixes(fset, a, d.SuggestedFixes); err != nil {
+						// Since we have diagnostics, the exit code will be nonzero,
+						// so logging these errors is sufficient.
+						log.Println(err)
+						d.SuggestedFixes = nil
+					}
+					act.diagnostics = append(act.diagnostics, d)
+				},
+				ImportObjectFact:  facts.ImportObjectFact,
+				ExportObjectFact:  facts.ExportObjectFact,
+				AllObjectFacts:    func() []analysis.ObjectFact { return facts.AllObjectFacts(factFilter) },
+				ImportPackageFact: facts.ImportPackageFact,
+				ExportPackageFact: facts.ExportPackageFact,
+				AllPackageFacts:   func() []analysis.PackageFact { return facts.AllPackageFacts(factFilter) },
+				Module:            module,
+			}
+			pass.ReadFile = driverutil.CheckedReadFile(pass, os.ReadFile)
+
+			t0 := time.Now()
+			act.result, act.err = a.Run(pass)
+
+			if act.err == nil { // resolve URLs on diagnostics.
+				for i := range act.diagnostics {
+					if url, uerr := driverutil.ResolveURL(a, act.diagnostics[i]); uerr == nil {
+						act.diagnostics[i].URL = url
+					} else {
+						act.err = uerr // keep the last error
+					}
+				}
+			}
+			if false {
+				log.Printf("analysis %s = %s", pass, time.Since(t0))
+			}
+		})
+		return act
+	}
+	execAll = func(analyzers []*analysis.Analyzer) {
+		var wg sync.WaitGroup
+		for _, a := range analyzers {
+			wg.Add(1)
+			go func(a *analysis.Analyzer) {
+				_ = exec(a)
+				wg.Done()
+			}(a)
+		}
+		wg.Wait()
+	}
+
+	execAll(analyzers)
+
+	// Return diagnostics and errors from root analyzers.
+	results := make([]result, len(analyzers))
+	for i, a := range analyzers {
+		act := actions[a]
+		results[i] = result{pkg, files, a, act.diagnostics, act.err}
+	}
+
+	data := facts.Encode()
+	if err := exportFacts(cfg, data); err != nil {
+		return nil, fmt.Errorf("failed to export analysis facts: %v", err)
+	}
+	if err := exportTypes(cfg, fset, pkg); err != nil {
+		return nil, fmt.Errorf("failed to export type information: %v", err)
+	}
+
+	return results, nil
+}
+
+type result struct {
+	pkg         *types.Package
+	files       []*ast.File
+	a           *analysis.Analyzer
+	diagnostics []analysis.Diagnostic
+	err         error
+}
+
+type importerFunc func(path string) (*types.Package, error)
+
+func (f importerFunc) Import(path string) (*types.Package, error) { return f(path) }

--- a/vendor/golang.org/x/tools/go/analysis/validate.go
+++ b/vendor/golang.org/x/tools/go/analysis/validate.go
@@ -1,0 +1,137 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package analysis
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+// Validate reports an error if any of the analyzers are misconfigured.
+// Checks include:
+// that the name is a valid identifier;
+// that the Doc is not empty;
+// that the Run is non-nil;
+// that the Requires graph is acyclic;
+// that analyzer fact types are unique;
+// that each fact type is a pointer.
+//
+// Analyzer names need not be unique, though this may be confusing.
+func Validate(analyzers []*Analyzer) error {
+	// Map each fact type to its sole generating analyzer.
+	factTypes := make(map[reflect.Type]*Analyzer)
+
+	// Traverse the Requires graph, depth first.
+	const (
+		white = iota
+		grey
+		black
+		finished
+	)
+	color := make(map[*Analyzer]uint8)
+	var visit func(a *Analyzer) error
+	visit = func(a *Analyzer) error {
+		if a == nil {
+			return fmt.Errorf("nil *Analyzer")
+		}
+		if color[a] == white {
+			color[a] = grey
+
+			// names
+			if !validIdent(a.Name) {
+				return fmt.Errorf("invalid analyzer name %q", a)
+			}
+
+			if a.Doc == "" {
+				return fmt.Errorf("analyzer %q is undocumented", a)
+			}
+
+			if a.Run == nil {
+				return fmt.Errorf("analyzer %q has nil Run", a)
+			}
+			// fact types
+			for _, f := range a.FactTypes {
+				if f == nil {
+					return fmt.Errorf("analyzer %s has nil FactType", a)
+				}
+				t := reflect.TypeOf(f)
+				if prev := factTypes[t]; prev != nil {
+					return fmt.Errorf("fact type %s registered by two analyzers: %v, %v",
+						t, a, prev)
+				}
+				if t.Kind() != reflect.Pointer {
+					return fmt.Errorf("%s: fact type %s is not a pointer", a, t)
+				}
+				factTypes[t] = a
+			}
+
+			// recursion
+			for _, req := range a.Requires {
+				if err := visit(req); err != nil {
+					return err
+				}
+			}
+			color[a] = black
+		}
+
+		if color[a] == grey {
+			stack := []*Analyzer{a}
+			inCycle := map[string]bool{}
+			for len(stack) > 0 {
+				current := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				if color[current] == grey && !inCycle[current.Name] {
+					inCycle[current.Name] = true
+					stack = append(stack, current.Requires...)
+				}
+			}
+			return &CycleInRequiresGraphError{AnalyzerNames: inCycle}
+		}
+
+		return nil
+	}
+	for _, a := range analyzers {
+		if err := visit(a); err != nil {
+			return err
+		}
+	}
+
+	// Reject duplicates among analyzers.
+	// Precondition:  color[a] == black.
+	// Postcondition: color[a] == finished.
+	for _, a := range analyzers {
+		if color[a] == finished {
+			return fmt.Errorf("duplicate analyzer: %s", a.Name)
+		}
+		color[a] = finished
+	}
+
+	return nil
+}
+
+func validIdent(name string) bool {
+	for i, r := range name {
+		if !(r == '_' || unicode.IsLetter(r) || i > 0 && unicode.IsDigit(r)) {
+			return false
+		}
+	}
+	return name != ""
+}
+
+type CycleInRequiresGraphError struct {
+	AnalyzerNames map[string]bool
+}
+
+func (e *CycleInRequiresGraphError) Error() string {
+	var b strings.Builder
+	b.WriteString("cycle detected involving the following analyzers:")
+	for n := range e.AnalyzerNames {
+		b.WriteByte(' ')
+		b.WriteString(n)
+	}
+	return b.String()
+}

--- a/vendor/golang.org/x/tools/go/ast/astutil/enclosing.go
+++ b/vendor/golang.org/x/tools/go/ast/astutil/enclosing.go
@@ -1,0 +1,663 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package astutil
+
+// This file defines utilities for working with source positions.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"sort"
+)
+
+// PathEnclosingInterval returns the node that encloses the source
+// interval [start, end), and all its ancestors up to the AST root.
+//
+// The definition of "enclosing" used by this function considers
+// additional whitespace abutting a node to be enclosed by it.
+// In this example:
+//
+//	z := x + y // add them
+//	     <-A->
+//	    <----B----->
+//
+// the ast.BinaryExpr(+) node is considered to enclose interval B
+// even though its [Pos()..End()) is actually only interval A.
+// This behaviour makes user interfaces more tolerant of imperfect
+// input.
+//
+// This function treats tokens as nodes, though they are not included
+// in the result. e.g. PathEnclosingInterval("+") returns the
+// enclosing ast.BinaryExpr("x + y").
+//
+// If start==end, the 1-char interval following start is used instead.
+//
+// The 'exact' result is true if the interval contains only path[0]
+// and perhaps some adjacent whitespace.  It is false if the interval
+// overlaps multiple children of path[0], or if it contains only
+// interior whitespace of path[0].
+// In this example:
+//
+//	z := x + y // add them
+//	  <--C-->     <---E-->
+//	    ^
+//	    D
+//
+// intervals C, D and E are inexact.  C is contained by the
+// z-assignment statement, because it spans three of its children (:=,
+// x, +).  So too is the 1-char interval D, because it contains only
+// interior whitespace of the assignment.  E is considered interior
+// whitespace of the BlockStmt containing the assignment.
+//
+// The resulting path is never empty; it always contains at least the
+// 'root' *ast.File.  Ideally PathEnclosingInterval would reject
+// intervals that lie wholly or partially outside the range of the
+// file, but unfortunately ast.File records only the token.Pos of
+// the 'package' keyword, but not of the start of the file itself.
+func PathEnclosingInterval(root *ast.File, start, end token.Pos) (path []ast.Node, exact bool) {
+	// fmt.Printf("EnclosingInterval %d %d\n", start, end) // debugging
+
+	// Precondition: node.[Pos..End) and adjoining whitespace contain [start, end).
+	var visit func(node ast.Node) bool
+	visit = func(node ast.Node) bool {
+		path = append(path, node)
+
+		nodePos := node.Pos()
+		nodeEnd := node.End()
+
+		// fmt.Printf("visit(%T, %d, %d)\n", node, nodePos, nodeEnd) // debugging
+
+		// Intersect [start, end) with interval of node.
+		if start < nodePos {
+			start = nodePos
+		}
+		if end > nodeEnd {
+			end = nodeEnd
+		}
+
+		// Find sole child that contains [start, end).
+		children := childrenOf(node)
+		l := len(children)
+		for i, child := range children {
+			// [childPos, childEnd) is unaugmented interval of child.
+			childPos := child.Pos()
+			childEnd := child.End()
+
+			// [augPos, augEnd) is whitespace-augmented interval of child.
+			augPos := childPos
+			augEnd := childEnd
+			if i > 0 {
+				augPos = children[i-1].End() // start of preceding whitespace
+			}
+			if i < l-1 {
+				nextChildPos := children[i+1].Pos()
+				// Does [start, end) lie between child and next child?
+				if start >= augEnd && end <= nextChildPos {
+					return false // inexact match
+				}
+				augEnd = nextChildPos // end of following whitespace
+			}
+
+			// fmt.Printf("\tchild %d: [%d..%d)\tcontains interval [%d..%d)?\n",
+			// 	i, augPos, augEnd, start, end) // debugging
+
+			// Does augmented child strictly contain [start, end)?
+			if augPos <= start && end <= augEnd {
+				if is[tokenNode](child) {
+					return true
+				}
+
+				// childrenOf elides the FuncType node beneath FuncDecl.
+				// Add it back here for TypeParams, Params, Results,
+				// all FieldLists). But we don't add it back for the "func" token
+				// even though it is the tree at FuncDecl.Type.Func.
+				if decl, ok := node.(*ast.FuncDecl); ok {
+					if fields, ok := child.(*ast.FieldList); ok && fields != decl.Recv {
+						path = append(path, decl.Type)
+					}
+				}
+
+				return visit(child)
+			}
+
+			// Does [start, end) overlap multiple children?
+			// i.e. left-augmented child contains start
+			// but LR-augmented child does not contain end.
+			if start < childEnd && end > augEnd {
+				break
+			}
+		}
+
+		// No single child contained [start, end),
+		// so node is the result.  Is it exact?
+
+		// (It's tempting to put this condition before the
+		// child loop, but it gives the wrong result in the
+		// case where a node (e.g. ExprStmt) and its sole
+		// child have equal intervals.)
+		if start == nodePos && end == nodeEnd {
+			return true // exact match
+		}
+
+		return false // inexact: overlaps multiple children
+	}
+
+	// Ensure [start,end) is nondecreasing.
+	if start > end {
+		start, end = end, start
+	}
+
+	if start < root.End() && end > root.Pos() {
+		if start == end {
+			end = start + 1 // empty interval => interval of size 1
+		}
+		exact = visit(root)
+
+		// Reverse the path:
+		for i, l := 0, len(path); i < l/2; i++ {
+			path[i], path[l-1-i] = path[l-1-i], path[i]
+		}
+	} else {
+		// Selection lies within whitespace preceding the
+		// first (or following the last) declaration in the file.
+		// The result nonetheless always includes the ast.File.
+		path = append(path, root)
+	}
+
+	return
+}
+
+// tokenNode is a dummy implementation of ast.Node for a single token.
+// They are used transiently by PathEnclosingInterval but never escape
+// this package.
+type tokenNode struct {
+	pos token.Pos
+	end token.Pos
+}
+
+func (n tokenNode) Pos() token.Pos {
+	return n.pos
+}
+
+func (n tokenNode) End() token.Pos {
+	return n.end
+}
+
+func tok(pos token.Pos, len int) ast.Node {
+	return tokenNode{pos, pos + token.Pos(len)}
+}
+
+// childrenOf returns the direct non-nil children of ast.Node n.
+// It may include fake ast.Node implementations for bare tokens.
+// it is not safe to call (e.g.) ast.Walk on such nodes.
+func childrenOf(n ast.Node) []ast.Node {
+	var children []ast.Node
+
+	// First add nodes for all true subtrees.
+	ast.Inspect(n, func(node ast.Node) bool {
+		if node == n { // push n
+			return true // recur
+		}
+		if node != nil { // push child
+			children = append(children, node)
+		}
+		return false // no recursion
+	})
+
+	// TODO(adonovan): be more careful about missing (!Pos.Valid)
+	// tokens in trees produced from invalid input.
+
+	// Then add fake Nodes for bare tokens.
+	switch n := n.(type) {
+	case *ast.ArrayType:
+		children = append(children,
+			tok(n.Lbrack, len("[")),
+			tok(n.Elt.End(), len("]")))
+
+	case *ast.AssignStmt:
+		children = append(children,
+			tok(n.TokPos, len(n.Tok.String())))
+
+	case *ast.BasicLit:
+		children = append(children,
+			tok(n.ValuePos, len(n.Value)))
+
+	case *ast.BinaryExpr:
+		children = append(children, tok(n.OpPos, len(n.Op.String())))
+
+	case *ast.BlockStmt:
+		if n.Lbrace.IsValid() {
+			children = append(children, tok(n.Lbrace, len("{")))
+		}
+		if n.Rbrace.IsValid() {
+			children = append(children, tok(n.Rbrace, len("}")))
+		}
+
+	case *ast.BranchStmt:
+		children = append(children,
+			tok(n.TokPos, len(n.Tok.String())))
+
+	case *ast.CallExpr:
+		children = append(children,
+			tok(n.Lparen, len("(")),
+			tok(n.Rparen, len(")")))
+		if n.Ellipsis != 0 {
+			children = append(children, tok(n.Ellipsis, len("...")))
+		}
+
+	case *ast.CaseClause:
+		if n.List == nil {
+			children = append(children,
+				tok(n.Case, len("default")))
+		} else {
+			children = append(children,
+				tok(n.Case, len("case")))
+		}
+		children = append(children, tok(n.Colon, len(":")))
+
+	case *ast.ChanType:
+		switch n.Dir {
+		case ast.RECV:
+			children = append(children, tok(n.Begin, len("<-chan")))
+		case ast.SEND:
+			children = append(children, tok(n.Begin, len("chan<-")))
+		case ast.RECV | ast.SEND:
+			children = append(children, tok(n.Begin, len("chan")))
+		}
+
+	case *ast.CommClause:
+		if n.Comm == nil {
+			children = append(children,
+				tok(n.Case, len("default")))
+		} else {
+			children = append(children,
+				tok(n.Case, len("case")))
+		}
+		children = append(children, tok(n.Colon, len(":")))
+
+	case *ast.Comment:
+		// nop
+
+	case *ast.CommentGroup:
+		// nop
+
+	case *ast.CompositeLit:
+		children = append(children,
+			tok(n.Lbrace, len("{")),
+			tok(n.Rbrace, len("{")))
+
+	case *ast.DeclStmt:
+		// nop
+
+	case *ast.DeferStmt:
+		children = append(children,
+			tok(n.Defer, len("defer")))
+
+	case *ast.Ellipsis:
+		children = append(children,
+			tok(n.Ellipsis, len("...")))
+
+	case *ast.EmptyStmt:
+		// nop
+
+	case *ast.ExprStmt:
+		// nop
+
+	case *ast.Field:
+		// TODO(adonovan): Field.{Doc,Comment,Tag}?
+
+	case *ast.FieldList:
+		if n.Opening.IsValid() {
+			children = append(children, tok(n.Opening, len("(")))
+		}
+		if n.Closing.IsValid() {
+			children = append(children, tok(n.Closing, len(")")))
+		}
+
+	case *ast.File:
+		// TODO test: Doc
+		children = append(children,
+			tok(n.Package, len("package")))
+
+	case *ast.ForStmt:
+		children = append(children,
+			tok(n.For, len("for")))
+
+	case *ast.FuncDecl:
+		// TODO(adonovan): FuncDecl.Comment?
+
+		// Uniquely, FuncDecl breaks the invariant that
+		// preorder traversal yields tokens in lexical order:
+		// in fact, FuncDecl.Recv precedes FuncDecl.Type.Func.
+		//
+		// As a workaround, we inline the case for FuncType
+		// here and order things correctly.
+		// We also need to insert the elided FuncType just
+		// before the 'visit' recursion.
+		//
+		children = nil // discard ast.Walk(FuncDecl) info subtrees
+		children = append(children, tok(n.Type.Func, len("func")))
+		if n.Recv != nil {
+			children = append(children, n.Recv)
+		}
+		children = append(children, n.Name)
+		if tparams := n.Type.TypeParams; tparams != nil {
+			children = append(children, tparams)
+		}
+		if n.Type.Params != nil {
+			children = append(children, n.Type.Params)
+		}
+		if n.Type.Results != nil {
+			children = append(children, n.Type.Results)
+		}
+		if n.Body != nil {
+			children = append(children, n.Body)
+		}
+
+	case *ast.FuncLit:
+		// nop
+
+	case *ast.FuncType:
+		if n.Func != 0 {
+			children = append(children,
+				tok(n.Func, len("func")))
+		}
+
+	case *ast.GenDecl:
+		children = append(children,
+			tok(n.TokPos, len(n.Tok.String())))
+		if n.Lparen != 0 {
+			children = append(children,
+				tok(n.Lparen, len("(")),
+				tok(n.Rparen, len(")")))
+		}
+
+	case *ast.GoStmt:
+		children = append(children,
+			tok(n.Go, len("go")))
+
+	case *ast.Ident:
+		children = append(children,
+			tok(n.NamePos, len(n.Name)))
+
+	case *ast.IfStmt:
+		children = append(children,
+			tok(n.If, len("if")))
+
+	case *ast.ImportSpec:
+		// TODO(adonovan): ImportSpec.{Doc,EndPos}?
+
+	case *ast.IncDecStmt:
+		children = append(children,
+			tok(n.TokPos, len(n.Tok.String())))
+
+	case *ast.IndexExpr:
+		children = append(children,
+			tok(n.Lbrack, len("[")),
+			tok(n.Rbrack, len("]")))
+
+	case *ast.IndexListExpr:
+		children = append(children,
+			tok(n.Lbrack, len("[")),
+			tok(n.Rbrack, len("]")))
+
+	case *ast.InterfaceType:
+		children = append(children,
+			tok(n.Interface, len("interface")))
+
+	case *ast.KeyValueExpr:
+		children = append(children,
+			tok(n.Colon, len(":")))
+
+	case *ast.LabeledStmt:
+		children = append(children,
+			tok(n.Colon, len(":")))
+
+	case *ast.MapType:
+		children = append(children,
+			tok(n.Map, len("map")))
+
+	case *ast.ParenExpr:
+		children = append(children,
+			tok(n.Lparen, len("(")),
+			tok(n.Rparen, len(")")))
+
+	case *ast.RangeStmt:
+		children = append(children,
+			tok(n.For, len("for")),
+			tok(n.TokPos, len(n.Tok.String())))
+
+	case *ast.ReturnStmt:
+		children = append(children,
+			tok(n.Return, len("return")))
+
+	case *ast.SelectStmt:
+		children = append(children,
+			tok(n.Select, len("select")))
+
+	case *ast.SelectorExpr:
+		// nop
+
+	case *ast.SendStmt:
+		children = append(children,
+			tok(n.Arrow, len("<-")))
+
+	case *ast.SliceExpr:
+		children = append(children,
+			tok(n.Lbrack, len("[")),
+			tok(n.Rbrack, len("]")))
+
+	case *ast.StarExpr:
+		children = append(children, tok(n.Star, len("*")))
+
+	case *ast.StructType:
+		children = append(children, tok(n.Struct, len("struct")))
+
+	case *ast.SwitchStmt:
+		children = append(children, tok(n.Switch, len("switch")))
+
+	case *ast.TypeAssertExpr:
+		children = append(children,
+			tok(n.Lparen-1, len(".")),
+			tok(n.Lparen, len("(")),
+			tok(n.Rparen, len(")")))
+
+	case *ast.TypeSpec:
+		// TODO(adonovan): TypeSpec.{Doc,Comment}?
+
+	case *ast.TypeSwitchStmt:
+		children = append(children, tok(n.Switch, len("switch")))
+
+	case *ast.UnaryExpr:
+		children = append(children, tok(n.OpPos, len(n.Op.String())))
+
+	case *ast.ValueSpec:
+		// TODO(adonovan): ValueSpec.{Doc,Comment}?
+
+	case *ast.BadDecl, *ast.BadExpr, *ast.BadStmt:
+		// nop
+	}
+
+	// TODO(adonovan): opt: merge the logic of ast.Inspect() into
+	// the switch above so we can make interleaved callbacks for
+	// both Nodes and Tokens in the right order and avoid the need
+	// to sort.
+	sort.Sort(byPos(children))
+
+	return children
+}
+
+type byPos []ast.Node
+
+func (sl byPos) Len() int {
+	return len(sl)
+}
+func (sl byPos) Less(i, j int) bool {
+	return sl[i].Pos() < sl[j].Pos()
+}
+func (sl byPos) Swap(i, j int) {
+	sl[i], sl[j] = sl[j], sl[i]
+}
+
+// NodeDescription returns a description of the concrete type of n suitable
+// for a user interface.
+//
+// TODO(adonovan): in some cases (e.g. Field, FieldList, Ident,
+// StarExpr) we could be much more specific given the path to the AST
+// root.  Perhaps we should do that.
+func NodeDescription(n ast.Node) string {
+	switch n := n.(type) {
+	case *ast.ArrayType:
+		return "array type"
+	case *ast.AssignStmt:
+		return "assignment"
+	case *ast.BadDecl:
+		return "bad declaration"
+	case *ast.BadExpr:
+		return "bad expression"
+	case *ast.BadStmt:
+		return "bad statement"
+	case *ast.BasicLit:
+		return "basic literal"
+	case *ast.BinaryExpr:
+		return fmt.Sprintf("binary %s operation", n.Op)
+	case *ast.BlockStmt:
+		return "block"
+	case *ast.BranchStmt:
+		switch n.Tok {
+		case token.BREAK:
+			return "break statement"
+		case token.CONTINUE:
+			return "continue statement"
+		case token.GOTO:
+			return "goto statement"
+		case token.FALLTHROUGH:
+			return "fall-through statement"
+		}
+	case *ast.CallExpr:
+		if len(n.Args) == 1 && !n.Ellipsis.IsValid() {
+			return "function call (or conversion)"
+		}
+		return "function call"
+	case *ast.CaseClause:
+		return "case clause"
+	case *ast.ChanType:
+		return "channel type"
+	case *ast.CommClause:
+		return "communication clause"
+	case *ast.Comment:
+		return "comment"
+	case *ast.CommentGroup:
+		return "comment group"
+	case *ast.CompositeLit:
+		return "composite literal"
+	case *ast.DeclStmt:
+		return NodeDescription(n.Decl) + " statement"
+	case *ast.DeferStmt:
+		return "defer statement"
+	case *ast.Ellipsis:
+		return "ellipsis"
+	case *ast.EmptyStmt:
+		return "empty statement"
+	case *ast.ExprStmt:
+		return "expression statement"
+	case *ast.Field:
+		// Can be any of these:
+		// struct {x, y int}  -- struct field(s)
+		// struct {T}         -- anon struct field
+		// interface {I}      -- interface embedding
+		// interface {f()}    -- interface method
+		// func (A) func(B) C -- receiver, param(s), result(s)
+		return "field/method/parameter"
+	case *ast.FieldList:
+		return "field/method/parameter list"
+	case *ast.File:
+		return "source file"
+	case *ast.ForStmt:
+		return "for loop"
+	case *ast.FuncDecl:
+		return "function declaration"
+	case *ast.FuncLit:
+		return "function literal"
+	case *ast.FuncType:
+		return "function type"
+	case *ast.GenDecl:
+		switch n.Tok {
+		case token.IMPORT:
+			return "import declaration"
+		case token.CONST:
+			return "constant declaration"
+		case token.TYPE:
+			return "type declaration"
+		case token.VAR:
+			return "variable declaration"
+		}
+	case *ast.GoStmt:
+		return "go statement"
+	case *ast.Ident:
+		return "identifier"
+	case *ast.IfStmt:
+		return "if statement"
+	case *ast.ImportSpec:
+		return "import specification"
+	case *ast.IncDecStmt:
+		if n.Tok == token.INC {
+			return "increment statement"
+		}
+		return "decrement statement"
+	case *ast.IndexExpr:
+		return "index expression"
+	case *ast.IndexListExpr:
+		return "index list expression"
+	case *ast.InterfaceType:
+		return "interface type"
+	case *ast.KeyValueExpr:
+		return "key/value association"
+	case *ast.LabeledStmt:
+		return "statement label"
+	case *ast.MapType:
+		return "map type"
+	case *ast.Package:
+		return "package"
+	case *ast.ParenExpr:
+		return "parenthesized " + NodeDescription(n.X)
+	case *ast.RangeStmt:
+		return "range loop"
+	case *ast.ReturnStmt:
+		return "return statement"
+	case *ast.SelectStmt:
+		return "select statement"
+	case *ast.SelectorExpr:
+		return "selector"
+	case *ast.SendStmt:
+		return "channel send"
+	case *ast.SliceExpr:
+		return "slice expression"
+	case *ast.StarExpr:
+		return "*-operation" // load/store expr or pointer type
+	case *ast.StructType:
+		return "struct type"
+	case *ast.SwitchStmt:
+		return "switch statement"
+	case *ast.TypeAssertExpr:
+		return "type assertion"
+	case *ast.TypeSpec:
+		return "type specification"
+	case *ast.TypeSwitchStmt:
+		return "type switch"
+	case *ast.UnaryExpr:
+		return fmt.Sprintf("unary %s operation", n.Op)
+	case *ast.ValueSpec:
+		return "value specification"
+
+	}
+	panic(fmt.Sprintf("unexpected node type: %T", n))
+}
+
+func is[T any](x any) bool {
+	_, ok := x.(T)
+	return ok
+}

--- a/vendor/golang.org/x/tools/go/ast/astutil/imports.go
+++ b/vendor/golang.org/x/tools/go/ast/astutil/imports.go
@@ -1,0 +1,487 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package astutil contains common utilities for working with the Go AST.
+package astutil // import "golang.org/x/tools/go/ast/astutil"
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// AddImport adds the import path to the file f, if absent.
+func AddImport(fset *token.FileSet, f *ast.File, path string) (added bool) {
+	return AddNamedImport(fset, f, "", path)
+}
+
+// AddNamedImport adds the import with the given name and path to the file f, if absent.
+// If name is not empty, it is used to rename the import.
+//
+// For example, calling
+//
+//	AddNamedImport(fset, f, "pathpkg", "path")
+//
+// adds
+//
+//	import pathpkg "path"
+func AddNamedImport(fset *token.FileSet, f *ast.File, name, path string) (added bool) {
+	if imports(f, name, path) {
+		return false
+	}
+
+	newImport := &ast.ImportSpec{
+		Path: &ast.BasicLit{
+			Kind:  token.STRING,
+			Value: strconv.Quote(path),
+		},
+	}
+	if name != "" {
+		newImport.Name = &ast.Ident{Name: name}
+	}
+
+	// Find an import decl to add to.
+	// The goal is to find an existing import
+	// whose import path has the longest shared
+	// prefix with path.
+	var (
+		bestMatch  = -1         // length of longest shared prefix
+		lastImport = -1         // index in f.Decls of the file's final import decl
+		impDecl    *ast.GenDecl // import decl containing the best match
+		impIndex   = -1         // spec index in impDecl containing the best match
+
+		isThirdPartyPath = isThirdParty(path)
+	)
+	for i, decl := range f.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if ok && gen.Tok == token.IMPORT {
+			lastImport = i
+			// Do not add to import "C", to avoid disrupting the
+			// association with its doc comment, breaking cgo.
+			if declImports(gen, "C") {
+				continue
+			}
+
+			// Match an empty import decl if that's all that is available.
+			if len(gen.Specs) == 0 && bestMatch == -1 {
+				impDecl = gen
+			}
+
+			// Compute longest shared prefix with imports in this group and find best
+			// matched import spec.
+			// 1. Always prefer import spec with longest shared prefix.
+			// 2. While match length is 0,
+			// - for stdlib package: prefer first import spec.
+			// - for third party package: prefer first third party import spec.
+			// We cannot use last import spec as best match for third party package
+			// because grouped imports are usually placed last by goimports -local
+			// flag.
+			// See issue #19190.
+			seenAnyThirdParty := false
+			for j, spec := range gen.Specs {
+				impspec := spec.(*ast.ImportSpec)
+				p := importPath(impspec)
+				n := matchLen(p, path)
+				if n > bestMatch || (bestMatch == 0 && !seenAnyThirdParty && isThirdPartyPath) {
+					bestMatch = n
+					impDecl = gen
+					impIndex = j
+				}
+				seenAnyThirdParty = seenAnyThirdParty || isThirdParty(p)
+			}
+		}
+	}
+
+	// If no import decl found, add one after the last import.
+	if impDecl == nil {
+		impDecl = &ast.GenDecl{
+			Tok: token.IMPORT,
+		}
+		if lastImport >= 0 {
+			impDecl.TokPos = f.Decls[lastImport].End()
+		} else {
+			// There are no existing imports.
+			// Our new import, preceded by a blank line,  goes after the package declaration
+			// and after the comment, if any, that starts on the same line as the
+			// package declaration.
+			impDecl.TokPos = f.Package
+
+			file := fset.File(f.Package)
+			pkgLine := file.Line(f.Package)
+			for _, c := range f.Comments {
+				if file.Line(c.Pos()) > pkgLine {
+					break
+				}
+				// +2 for a blank line
+				impDecl.TokPos = c.End() + 2
+			}
+		}
+		f.Decls = append(f.Decls, nil)
+		copy(f.Decls[lastImport+2:], f.Decls[lastImport+1:])
+		f.Decls[lastImport+1] = impDecl
+	}
+
+	// Insert new import at insertAt.
+	insertAt := 0
+	if impIndex >= 0 {
+		// insert after the found import
+		insertAt = impIndex + 1
+	}
+	impDecl.Specs = append(impDecl.Specs, nil)
+	copy(impDecl.Specs[insertAt+1:], impDecl.Specs[insertAt:])
+	impDecl.Specs[insertAt] = newImport
+	pos := impDecl.Pos()
+	if insertAt > 0 {
+		// If there is a comment after an existing import, preserve the comment
+		// position by adding the new import after the comment.
+		if spec, ok := impDecl.Specs[insertAt-1].(*ast.ImportSpec); ok && spec.Comment != nil {
+			pos = spec.Comment.End()
+		} else {
+			// Assign same position as the previous import,
+			// so that the sorter sees it as being in the same block.
+			pos = impDecl.Specs[insertAt-1].Pos()
+		}
+	}
+	if newImport.Name != nil {
+		newImport.Name.NamePos = pos
+	}
+	updateBasicLitPos(newImport.Path, pos)
+	newImport.EndPos = pos
+
+	// Clean up parens. impDecl contains at least one spec.
+	if len(impDecl.Specs) == 1 {
+		// Remove unneeded parens.
+		impDecl.Lparen = token.NoPos
+	} else if !impDecl.Lparen.IsValid() {
+		// impDecl needs parens added.
+		impDecl.Lparen = impDecl.Specs[0].Pos()
+	}
+
+	f.Imports = append(f.Imports, newImport)
+
+	if len(f.Decls) <= 1 {
+		return true
+	}
+
+	// Merge all the import declarations into the first one.
+	var first *ast.GenDecl
+	for i := 0; i < len(f.Decls); i++ {
+		decl := f.Decls[i]
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.IMPORT || declImports(gen, "C") {
+			continue
+		}
+		if first == nil {
+			first = gen
+			continue // Don't touch the first one.
+		}
+		// We now know there is more than one package in this import
+		// declaration. Ensure that it ends up parenthesized.
+		first.Lparen = first.Pos()
+		// Move the imports of the other import declaration to the first one.
+		for _, spec := range gen.Specs {
+			updateBasicLitPos(spec.(*ast.ImportSpec).Path, first.Pos())
+			first.Specs = append(first.Specs, spec)
+		}
+		f.Decls = slices.Delete(f.Decls, i, i+1)
+		i--
+	}
+
+	return true
+}
+
+func isThirdParty(importPath string) bool {
+	// Third party package import path usually contains "." (".com", ".org", ...)
+	// This logic is taken from golang.org/x/tools/imports package.
+	return strings.Contains(importPath, ".")
+}
+
+// DeleteImport deletes the import path from the file f, if present.
+// If there are duplicate import declarations, all matching ones are deleted.
+func DeleteImport(fset *token.FileSet, f *ast.File, path string) (deleted bool) {
+	return DeleteNamedImport(fset, f, "", path)
+}
+
+// DeleteNamedImport deletes the import with the given name and path from the file f, if present.
+// If there are duplicate import declarations, all matching ones are deleted.
+func DeleteNamedImport(fset *token.FileSet, f *ast.File, name, path string) (deleted bool) {
+	var (
+		delspecs    = make(map[*ast.ImportSpec]bool)
+		delcomments = make(map[*ast.CommentGroup]bool)
+	)
+
+	// Find the import nodes that import path, if any.
+	for i := 0; i < len(f.Decls); i++ {
+		gen, ok := f.Decls[i].(*ast.GenDecl)
+		if !ok || gen.Tok != token.IMPORT {
+			continue
+		}
+		for j := 0; j < len(gen.Specs); j++ {
+			impspec := gen.Specs[j].(*ast.ImportSpec)
+			if importName(impspec) != name || importPath(impspec) != path {
+				continue
+			}
+
+			// We found an import spec that imports path.
+			// Delete it.
+			delspecs[impspec] = true
+			deleted = true
+			gen.Specs = slices.Delete(gen.Specs, j, j+1)
+
+			// If this was the last import spec in this decl,
+			// delete the decl, too.
+			if len(gen.Specs) == 0 {
+				f.Decls = slices.Delete(f.Decls, i, i+1)
+				i--
+				break
+			} else if len(gen.Specs) == 1 {
+				if impspec.Doc != nil {
+					delcomments[impspec.Doc] = true
+				}
+				if impspec.Comment != nil {
+					delcomments[impspec.Comment] = true
+				}
+				for _, cg := range f.Comments {
+					// Found comment on the same line as the import spec.
+					if cg.End() < impspec.Pos() && fset.Position(cg.End()).Line == fset.Position(impspec.Pos()).Line {
+						delcomments[cg] = true
+						break
+					}
+				}
+
+				spec := gen.Specs[0].(*ast.ImportSpec)
+
+				// Move the documentation right after the import decl.
+				if spec.Doc != nil {
+					for fset.Position(gen.TokPos).Line+1 < fset.Position(spec.Doc.Pos()).Line {
+						fset.File(gen.TokPos).MergeLine(fset.Position(gen.TokPos).Line)
+					}
+				}
+				for _, cg := range f.Comments {
+					if cg.End() < spec.Pos() && fset.Position(cg.End()).Line == fset.Position(spec.Pos()).Line {
+						for fset.Position(gen.TokPos).Line+1 < fset.Position(spec.Pos()).Line {
+							fset.File(gen.TokPos).MergeLine(fset.Position(gen.TokPos).Line)
+						}
+						break
+					}
+				}
+			}
+			if j > 0 {
+				lastImpspec := gen.Specs[j-1].(*ast.ImportSpec)
+				lastLine := fset.PositionFor(lastImpspec.Path.ValuePos, false).Line
+				line := fset.PositionFor(impspec.Path.ValuePos, false).Line
+
+				// We deleted an entry but now there may be
+				// a blank line-sized hole where the import was.
+				if line-lastLine > 1 || !gen.Rparen.IsValid() {
+					// There was a blank line immediately preceding the deleted import,
+					// so there's no need to close the hole. The right parenthesis is
+					// invalid after AddImport to an import statement without parenthesis.
+					// Do nothing.
+				} else if line != fset.File(gen.Rparen).LineCount() {
+					// There was no blank line. Close the hole.
+					fset.File(gen.Rparen).MergeLine(line)
+				}
+			}
+			j--
+		}
+	}
+
+	// Delete imports from f.Imports.
+	before := len(f.Imports)
+	f.Imports = slices.DeleteFunc(f.Imports, func(imp *ast.ImportSpec) bool {
+		_, ok := delspecs[imp]
+		return ok
+	})
+	if len(f.Imports)+len(delspecs) != before {
+		// This can happen when the AST is invalid (i.e. imports differ between f.Decls and f.Imports).
+		panic(fmt.Sprintf("deleted specs from Decls but not Imports: %v", delspecs))
+	}
+
+	// Delete comments from f.Comments.
+	f.Comments = slices.DeleteFunc(f.Comments, func(cg *ast.CommentGroup) bool {
+		_, ok := delcomments[cg]
+		return ok
+	})
+
+	return
+}
+
+// RewriteImport rewrites any import of path oldPath to path newPath.
+func RewriteImport(fset *token.FileSet, f *ast.File, oldPath, newPath string) (rewrote bool) {
+	for _, imp := range f.Imports {
+		if importPath(imp) == oldPath {
+			rewrote = true
+			// record old End, because the default is to compute
+			// it using the length of imp.Path.Value.
+			imp.EndPos = imp.End()
+			imp.Path.Value = strconv.Quote(newPath)
+		}
+	}
+	return
+}
+
+// UsesImport reports whether a given import is used.
+// The provided File must have been parsed with syntactic object resolution
+// (not using go/parser.SkipObjectResolution).
+func UsesImport(f *ast.File, path string) (used bool) {
+	if f.Scope == nil {
+		panic("file f was not parsed with syntactic object resolution")
+	}
+	spec := importSpec(f, path)
+	if spec == nil {
+		return
+	}
+
+	name := spec.Name.String()
+	switch name {
+	case "<nil>":
+		// If the package name is not explicitly specified,
+		// make an educated guess. This is not guaranteed to be correct.
+		lastSlash := strings.LastIndex(path, "/")
+		if lastSlash == -1 {
+			name = path
+		} else {
+			name = path[lastSlash+1:]
+		}
+	case "_", ".":
+		// Not sure if this import is used - err on the side of caution.
+		return true
+	}
+
+	ast.Walk(visitFn(func(n ast.Node) {
+		sel, ok := n.(*ast.SelectorExpr)
+		if ok && isTopName(sel.X, name) {
+			used = true
+		}
+	}), f)
+
+	return
+}
+
+type visitFn func(node ast.Node)
+
+func (fn visitFn) Visit(node ast.Node) ast.Visitor {
+	fn(node)
+	return fn
+}
+
+// imports reports whether f has an import with the specified name and path.
+func imports(f *ast.File, name, path string) bool {
+	for _, s := range f.Imports {
+		if importName(s) == name && importPath(s) == path {
+			return true
+		}
+	}
+	return false
+}
+
+// importSpec returns the import spec if f imports path,
+// or nil otherwise.
+func importSpec(f *ast.File, path string) *ast.ImportSpec {
+	for _, s := range f.Imports {
+		if importPath(s) == path {
+			return s
+		}
+	}
+	return nil
+}
+
+// importName returns the name of s,
+// or "" if the import is not named.
+func importName(s *ast.ImportSpec) string {
+	if s.Name == nil {
+		return ""
+	}
+	return s.Name.Name
+}
+
+// importPath returns the unquoted import path of s,
+// or "" if the path is not properly quoted.
+func importPath(s *ast.ImportSpec) string {
+	t, err := strconv.Unquote(s.Path.Value)
+	if err != nil {
+		return ""
+	}
+	return t
+}
+
+// declImports reports whether gen contains an import of path.
+func declImports(gen *ast.GenDecl, path string) bool {
+	if gen.Tok != token.IMPORT {
+		return false
+	}
+	for _, spec := range gen.Specs {
+		impspec := spec.(*ast.ImportSpec)
+		if importPath(impspec) == path {
+			return true
+		}
+	}
+	return false
+}
+
+// matchLen returns the length of the longest path segment prefix shared by x and y.
+func matchLen(x, y string) int {
+	n := 0
+	for i := 0; i < len(x) && i < len(y) && x[i] == y[i]; i++ {
+		if x[i] == '/' {
+			n++
+		}
+	}
+	return n
+}
+
+// isTopName returns true if n is a top-level unresolved identifier with the given name.
+func isTopName(n ast.Expr, name string) bool {
+	id, ok := n.(*ast.Ident)
+	return ok && id.Name == name && id.Obj == nil
+}
+
+// Imports returns the file imports grouped by paragraph.
+func Imports(fset *token.FileSet, f *ast.File) [][]*ast.ImportSpec {
+	var groups [][]*ast.ImportSpec
+
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.IMPORT {
+			break
+		}
+
+		group := []*ast.ImportSpec{}
+
+		var lastLine int
+		for _, spec := range genDecl.Specs {
+			importSpec := spec.(*ast.ImportSpec)
+			pos := importSpec.Path.ValuePos
+			line := fset.Position(pos).Line
+			if lastLine > 0 && pos > 0 && line-lastLine > 1 {
+				groups = append(groups, group)
+				group = []*ast.ImportSpec{}
+			}
+			group = append(group, importSpec)
+			lastLine = line
+		}
+		groups = append(groups, group)
+	}
+
+	return groups
+}
+
+// updateBasicLitPos updates lit.Pos,
+// ensuring that lit.End (if set) is displaced by the same amount.
+// (See https://go.dev/issue/76395.)
+func updateBasicLitPos(lit *ast.BasicLit, pos token.Pos) {
+	len := lit.End() - lit.Pos()
+	lit.ValuePos = pos
+	// TODO(adonovan): after go1.26, simplify to:
+	//   lit.ValueEnd = pos + len
+	v := reflect.ValueOf(lit).Elem().FieldByName("ValueEnd")
+	if v.IsValid() && v.Int() != 0 {
+		v.SetInt(int64(pos + len))
+	}
+}

--- a/vendor/golang.org/x/tools/go/ast/astutil/rewrite.go
+++ b/vendor/golang.org/x/tools/go/ast/astutil/rewrite.go
@@ -1,0 +1,490 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package astutil
+
+import (
+	"fmt"
+	"go/ast"
+	"reflect"
+	"sort"
+)
+
+// An ApplyFunc is invoked by Apply for each node n, even if n is nil,
+// before and/or after the node's children, using a Cursor describing
+// the current node and providing operations on it.
+//
+// The return value of ApplyFunc controls the syntax tree traversal.
+// See Apply for details.
+type ApplyFunc func(*Cursor) bool
+
+// Apply traverses a syntax tree recursively, starting with root,
+// and calling pre and post for each node as described below.
+// Apply returns the syntax tree, possibly modified.
+//
+// If pre is not nil, it is called for each node before the node's
+// children are traversed (pre-order). If pre returns false, no
+// children are traversed, and post is not called for that node.
+//
+// If post is not nil, and a prior call of pre didn't return false,
+// post is called for each node after its children are traversed
+// (post-order). If post returns false, traversal is terminated and
+// Apply returns immediately.
+//
+// Only fields that refer to AST nodes are considered children;
+// i.e., token.Pos, Scopes, Objects, and fields of basic types
+// (strings, etc.) are ignored.
+//
+// Children are traversed in the order in which they appear in the
+// respective node's struct definition. A package's files are
+// traversed in the filenames' alphabetical order.
+func Apply(root ast.Node, pre, post ApplyFunc) (result ast.Node) {
+	parent := &struct{ ast.Node }{root}
+	defer func() {
+		if r := recover(); r != nil && r != abort {
+			panic(r)
+		}
+		result = parent.Node
+	}()
+	a := &application{pre: pre, post: post}
+	a.apply(parent, "Node", nil, root)
+	return
+}
+
+var abort = new(int) // singleton, to signal termination of Apply
+
+// A Cursor describes a node encountered during Apply.
+// Information about the node and its parent is available
+// from the Node, Parent, Name, and Index methods.
+//
+// If p is a variable of type and value of the current parent node
+// c.Parent(), and f is the field identifier with name c.Name(),
+// the following invariants hold:
+//
+//	p.f            == c.Node()  if c.Index() <  0
+//	p.f[c.Index()] == c.Node()  if c.Index() >= 0
+//
+// The methods Replace, Delete, InsertBefore, and InsertAfter
+// can be used to change the AST without disrupting Apply.
+//
+// This type is not to be confused with [inspector.Cursor] from
+// package [golang.org/x/tools/go/ast/inspector], which provides
+// stateless navigation of immutable syntax trees.
+type Cursor struct {
+	parent ast.Node
+	name   string
+	iter   *iterator // valid if non-nil
+	node   ast.Node
+}
+
+// Node returns the current Node.
+func (c *Cursor) Node() ast.Node { return c.node }
+
+// Parent returns the parent of the current Node.
+func (c *Cursor) Parent() ast.Node { return c.parent }
+
+// Name returns the name of the parent Node field that contains the current Node.
+// If the parent is a *ast.Package and the current Node is a *ast.File, Name returns
+// the filename for the current Node.
+func (c *Cursor) Name() string { return c.name }
+
+// Index reports the index >= 0 of the current Node in the slice of Nodes that
+// contains it, or a value < 0 if the current Node is not part of a slice.
+// The index of the current node changes if InsertBefore is called while
+// processing the current node.
+func (c *Cursor) Index() int {
+	if c.iter != nil {
+		return c.iter.index
+	}
+	return -1
+}
+
+// field returns the current node's parent field value.
+func (c *Cursor) field() reflect.Value {
+	return reflect.Indirect(reflect.ValueOf(c.parent)).FieldByName(c.name)
+}
+
+// Replace replaces the current Node with n.
+// The replacement node is not walked by Apply.
+func (c *Cursor) Replace(n ast.Node) {
+	if _, ok := c.node.(*ast.File); ok {
+		file, ok := n.(*ast.File)
+		if !ok {
+			panic("attempt to replace *ast.File with non-*ast.File")
+		}
+		c.parent.(*ast.Package).Files[c.name] = file
+		return
+	}
+
+	v := c.field()
+	if i := c.Index(); i >= 0 {
+		v = v.Index(i)
+	}
+	v.Set(reflect.ValueOf(n))
+}
+
+// Delete deletes the current Node from its containing slice.
+// If the current Node is not part of a slice, Delete panics.
+// As a special case, if the current node is a package file,
+// Delete removes it from the package's Files map.
+func (c *Cursor) Delete() {
+	if _, ok := c.node.(*ast.File); ok {
+		delete(c.parent.(*ast.Package).Files, c.name)
+		return
+	}
+
+	i := c.Index()
+	if i < 0 {
+		panic("Delete node not contained in slice")
+	}
+	v := c.field()
+	l := v.Len()
+	reflect.Copy(v.Slice(i, l), v.Slice(i+1, l))
+	v.Index(l - 1).Set(reflect.Zero(v.Type().Elem()))
+	v.SetLen(l - 1)
+	c.iter.step--
+}
+
+// InsertAfter inserts n after the current Node in its containing slice.
+// If the current Node is not part of a slice, InsertAfter panics.
+// Apply does not walk n.
+func (c *Cursor) InsertAfter(n ast.Node) {
+	i := c.Index()
+	if i < 0 {
+		panic("InsertAfter node not contained in slice")
+	}
+	v := c.field()
+	v.Set(reflect.Append(v, reflect.Zero(v.Type().Elem())))
+	l := v.Len()
+	reflect.Copy(v.Slice(i+2, l), v.Slice(i+1, l))
+	v.Index(i + 1).Set(reflect.ValueOf(n))
+	c.iter.step++
+}
+
+// InsertBefore inserts n before the current Node in its containing slice.
+// If the current Node is not part of a slice, InsertBefore panics.
+// Apply will not walk n.
+func (c *Cursor) InsertBefore(n ast.Node) {
+	i := c.Index()
+	if i < 0 {
+		panic("InsertBefore node not contained in slice")
+	}
+	v := c.field()
+	v.Set(reflect.Append(v, reflect.Zero(v.Type().Elem())))
+	l := v.Len()
+	reflect.Copy(v.Slice(i+1, l), v.Slice(i, l))
+	v.Index(i).Set(reflect.ValueOf(n))
+	c.iter.index++
+}
+
+// application carries all the shared data so we can pass it around cheaply.
+type application struct {
+	pre, post ApplyFunc
+	cursor    Cursor
+	iter      iterator
+}
+
+func (a *application) apply(parent ast.Node, name string, iter *iterator, n ast.Node) {
+	// convert typed nil into untyped nil
+	if v := reflect.ValueOf(n); v.Kind() == reflect.Pointer && v.IsNil() {
+		n = nil
+	}
+
+	// avoid heap-allocating a new cursor for each apply call; reuse a.cursor instead
+	saved := a.cursor
+	a.cursor.parent = parent
+	a.cursor.name = name
+	a.cursor.iter = iter
+	a.cursor.node = n
+
+	if a.pre != nil && !a.pre(&a.cursor) {
+		a.cursor = saved
+		return
+	}
+
+	// walk children
+	// (the order of the cases matches the order of the corresponding node types in go/ast)
+	switch n := n.(type) {
+	case nil:
+		// nothing to do
+
+	// Comments and fields
+	case *ast.Comment:
+		// nothing to do
+
+	case *ast.CommentGroup:
+		if n != nil {
+			a.applyList(n, "List")
+		}
+
+	case *ast.Field:
+		a.apply(n, "Doc", nil, n.Doc)
+		a.applyList(n, "Names")
+		a.apply(n, "Type", nil, n.Type)
+		a.apply(n, "Tag", nil, n.Tag)
+		a.apply(n, "Comment", nil, n.Comment)
+
+	case *ast.FieldList:
+		a.applyList(n, "List")
+
+	// Expressions
+	case *ast.BadExpr, *ast.Ident, *ast.BasicLit:
+		// nothing to do
+
+	case *ast.Ellipsis:
+		a.apply(n, "Elt", nil, n.Elt)
+
+	case *ast.FuncLit:
+		a.apply(n, "Type", nil, n.Type)
+		a.apply(n, "Body", nil, n.Body)
+
+	case *ast.CompositeLit:
+		a.apply(n, "Type", nil, n.Type)
+		a.applyList(n, "Elts")
+
+	case *ast.ParenExpr:
+		a.apply(n, "X", nil, n.X)
+
+	case *ast.SelectorExpr:
+		a.apply(n, "X", nil, n.X)
+		a.apply(n, "Sel", nil, n.Sel)
+
+	case *ast.IndexExpr:
+		a.apply(n, "X", nil, n.X)
+		a.apply(n, "Index", nil, n.Index)
+
+	case *ast.IndexListExpr:
+		a.apply(n, "X", nil, n.X)
+		a.applyList(n, "Indices")
+
+	case *ast.SliceExpr:
+		a.apply(n, "X", nil, n.X)
+		a.apply(n, "Low", nil, n.Low)
+		a.apply(n, "High", nil, n.High)
+		a.apply(n, "Max", nil, n.Max)
+
+	case *ast.TypeAssertExpr:
+		a.apply(n, "X", nil, n.X)
+		a.apply(n, "Type", nil, n.Type)
+
+	case *ast.CallExpr:
+		a.apply(n, "Fun", nil, n.Fun)
+		a.applyList(n, "Args")
+
+	case *ast.StarExpr:
+		a.apply(n, "X", nil, n.X)
+
+	case *ast.UnaryExpr:
+		a.apply(n, "X", nil, n.X)
+
+	case *ast.BinaryExpr:
+		a.apply(n, "X", nil, n.X)
+		a.apply(n, "Y", nil, n.Y)
+
+	case *ast.KeyValueExpr:
+		a.apply(n, "Key", nil, n.Key)
+		a.apply(n, "Value", nil, n.Value)
+
+	// Types
+	case *ast.ArrayType:
+		a.apply(n, "Len", nil, n.Len)
+		a.apply(n, "Elt", nil, n.Elt)
+
+	case *ast.StructType:
+		a.apply(n, "Fields", nil, n.Fields)
+
+	case *ast.FuncType:
+		if tparams := n.TypeParams; tparams != nil {
+			a.apply(n, "TypeParams", nil, tparams)
+		}
+		a.apply(n, "Params", nil, n.Params)
+		a.apply(n, "Results", nil, n.Results)
+
+	case *ast.InterfaceType:
+		a.apply(n, "Methods", nil, n.Methods)
+
+	case *ast.MapType:
+		a.apply(n, "Key", nil, n.Key)
+		a.apply(n, "Value", nil, n.Value)
+
+	case *ast.ChanType:
+		a.apply(n, "Value", nil, n.Value)
+
+	// Statements
+	case *ast.BadStmt:
+		// nothing to do
+
+	case *ast.DeclStmt:
+		a.apply(n, "Decl", nil, n.Decl)
+
+	case *ast.EmptyStmt:
+		// nothing to do
+
+	case *ast.LabeledStmt:
+		a.apply(n, "Label", nil, n.Label)
+		a.apply(n, "Stmt", nil, n.Stmt)
+
+	case *ast.ExprStmt:
+		a.apply(n, "X", nil, n.X)
+
+	case *ast.SendStmt:
+		a.apply(n, "Chan", nil, n.Chan)
+		a.apply(n, "Value", nil, n.Value)
+
+	case *ast.IncDecStmt:
+		a.apply(n, "X", nil, n.X)
+
+	case *ast.AssignStmt:
+		a.applyList(n, "Lhs")
+		a.applyList(n, "Rhs")
+
+	case *ast.GoStmt:
+		a.apply(n, "Call", nil, n.Call)
+
+	case *ast.DeferStmt:
+		a.apply(n, "Call", nil, n.Call)
+
+	case *ast.ReturnStmt:
+		a.applyList(n, "Results")
+
+	case *ast.BranchStmt:
+		a.apply(n, "Label", nil, n.Label)
+
+	case *ast.BlockStmt:
+		a.applyList(n, "List")
+
+	case *ast.IfStmt:
+		a.apply(n, "Init", nil, n.Init)
+		a.apply(n, "Cond", nil, n.Cond)
+		a.apply(n, "Body", nil, n.Body)
+		a.apply(n, "Else", nil, n.Else)
+
+	case *ast.CaseClause:
+		a.applyList(n, "List")
+		a.applyList(n, "Body")
+
+	case *ast.SwitchStmt:
+		a.apply(n, "Init", nil, n.Init)
+		a.apply(n, "Tag", nil, n.Tag)
+		a.apply(n, "Body", nil, n.Body)
+
+	case *ast.TypeSwitchStmt:
+		a.apply(n, "Init", nil, n.Init)
+		a.apply(n, "Assign", nil, n.Assign)
+		a.apply(n, "Body", nil, n.Body)
+
+	case *ast.CommClause:
+		a.apply(n, "Comm", nil, n.Comm)
+		a.applyList(n, "Body")
+
+	case *ast.SelectStmt:
+		a.apply(n, "Body", nil, n.Body)
+
+	case *ast.ForStmt:
+		a.apply(n, "Init", nil, n.Init)
+		a.apply(n, "Cond", nil, n.Cond)
+		a.apply(n, "Post", nil, n.Post)
+		a.apply(n, "Body", nil, n.Body)
+
+	case *ast.RangeStmt:
+		a.apply(n, "Key", nil, n.Key)
+		a.apply(n, "Value", nil, n.Value)
+		a.apply(n, "X", nil, n.X)
+		a.apply(n, "Body", nil, n.Body)
+
+	// Declarations
+	case *ast.ImportSpec:
+		a.apply(n, "Doc", nil, n.Doc)
+		a.apply(n, "Name", nil, n.Name)
+		a.apply(n, "Path", nil, n.Path)
+		a.apply(n, "Comment", nil, n.Comment)
+
+	case *ast.ValueSpec:
+		a.apply(n, "Doc", nil, n.Doc)
+		a.applyList(n, "Names")
+		a.apply(n, "Type", nil, n.Type)
+		a.applyList(n, "Values")
+		a.apply(n, "Comment", nil, n.Comment)
+
+	case *ast.TypeSpec:
+		a.apply(n, "Doc", nil, n.Doc)
+		a.apply(n, "Name", nil, n.Name)
+		if tparams := n.TypeParams; tparams != nil {
+			a.apply(n, "TypeParams", nil, tparams)
+		}
+		a.apply(n, "Type", nil, n.Type)
+		a.apply(n, "Comment", nil, n.Comment)
+
+	case *ast.BadDecl:
+		// nothing to do
+
+	case *ast.GenDecl:
+		a.apply(n, "Doc", nil, n.Doc)
+		a.applyList(n, "Specs")
+
+	case *ast.FuncDecl:
+		a.apply(n, "Doc", nil, n.Doc)
+		a.apply(n, "Recv", nil, n.Recv)
+		a.apply(n, "Name", nil, n.Name)
+		a.apply(n, "Type", nil, n.Type)
+		a.apply(n, "Body", nil, n.Body)
+
+	// Files and packages
+	case *ast.File:
+		a.apply(n, "Doc", nil, n.Doc)
+		a.apply(n, "Name", nil, n.Name)
+		a.applyList(n, "Decls")
+		// Don't walk n.Comments; they have either been walked already if
+		// they are Doc comments, or they can be easily walked explicitly.
+
+	case *ast.Package:
+		// collect and sort names for reproducible behavior
+		var names []string
+		for name := range n.Files {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			a.apply(n, name, nil, n.Files[name])
+		}
+
+	default:
+		panic(fmt.Sprintf("Apply: unexpected node type %T", n))
+	}
+
+	if a.post != nil && !a.post(&a.cursor) {
+		panic(abort)
+	}
+
+	a.cursor = saved
+}
+
+// An iterator controls iteration over a slice of nodes.
+type iterator struct {
+	index, step int
+}
+
+func (a *application) applyList(parent ast.Node, name string) {
+	// avoid heap-allocating a new iterator for each applyList call; reuse a.iter instead
+	saved := a.iter
+	a.iter.index = 0
+	for {
+		// must reload parent.name each time, since cursor modifications might change it
+		v := reflect.Indirect(reflect.ValueOf(parent)).FieldByName(name)
+		if a.iter.index >= v.Len() {
+			break
+		}
+
+		// element x may be nil in a bad AST - be cautious
+		var x ast.Node
+		if e := v.Index(a.iter.index); e.IsValid() {
+			x = e.Interface().(ast.Node)
+		}
+
+		a.iter.step = 1
+		a.apply(parent, name, &a.iter, x)
+		a.iter.index += a.iter.step
+	}
+	a.iter = saved
+}

--- a/vendor/golang.org/x/tools/go/ast/astutil/util.go
+++ b/vendor/golang.org/x/tools/go/ast/astutil/util.go
@@ -1,0 +1,13 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package astutil
+
+import "go/ast"
+
+// Unparen returns e with any enclosing parentheses stripped.
+// Deprecated: use [ast.Unparen].
+//
+//go:fix inline
+func Unparen(e ast.Expr) ast.Expr { return ast.Unparen(e) }

--- a/vendor/golang.org/x/tools/internal/analysis/driverutil/fix.go
+++ b/vendor/golang.org/x/tools/internal/analysis/driverutil/fix.go
@@ -1,0 +1,466 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package driverutil defines implementation helper functions for
+// analysis drivers such as unitchecker, {single,multi}checker, and
+// analysistest.
+package driverutil
+
+// This file defines the -fix logic common to unitchecker and
+// {single,multi}checker.
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"go/types"
+	"log"
+	"maps"
+	"os"
+	"sort"
+	"strconv"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/internal/astutil/free"
+	"golang.org/x/tools/internal/diff"
+)
+
+// FixAction abstracts a checker action (running one analyzer on one
+// package) for the purposes of applying its diagnostics' fixes.
+type FixAction struct {
+	Name         string         // e.g. "analyzer@package"
+	Pkg          *types.Package // (for import removal)
+	Files        []*ast.File
+	FileSet      *token.FileSet
+	ReadFileFunc ReadFileFunc
+	Diagnostics  []analysis.Diagnostic
+}
+
+// ApplyFixes attempts to apply the first suggested fix associated
+// with each diagnostic reported by the specified actions.
+// All fixes must have been validated by [ValidateFixes].
+//
+// Each fix is treated as an independent change; fixes are merged in
+// an arbitrary deterministic order as if by a three-way diff tool
+// such as the UNIX diff3 command or 'git merge'. Any fix that cannot be
+// cleanly merged is discarded, in which case the final summary tells
+// the user to re-run the tool.
+// TODO(adonovan): make the checker tool re-run the analysis itself.
+//
+// When the same file is analyzed as a member of both a primary
+// package "p" and a test-augmented package "p [p.test]", there may be
+// duplicate diagnostics and fixes. One set of fixes will be applied
+// and the other will be discarded; but re-running the tool may then
+// show zero fixes, which may cause the confused user to wonder what
+// happened to the other ones.
+// TODO(adonovan): consider pre-filtering completely identical fixes.
+//
+// A common reason for overlapping fixes is duplicate additions of the
+// same import. The merge algorithm may often cleanly resolve such
+// fixes, coalescing identical edits, but the merge may sometimes be
+// confused by nearby changes.
+//
+// Even when merging succeeds, there is no guarantee that the
+// composition of the two fixes is semantically correct. Coalescing
+// identical edits is appropriate for imports, but not for, say,
+// increments to a counter variable; the correct resolution in that
+// case might be to increment it twice.
+//
+// Or consider two fixes that each delete the penultimate reference to
+// a local variable: each fix is sound individually, and they may be
+// textually distant from each other, but when both are applied, the
+// program is no longer valid because it has an unreferenced local
+// variable. (ApplyFixes solves the analogous problem for imports by
+// eliminating imports whose name is unreferenced in the remainder of
+// the fixed file.)
+//
+// Merging depends on both the order of fixes and they order of edits
+// within them. For example, if three fixes add import "a" twice and
+// import "b" once, the two imports of "a" may be combined if they
+// appear in order [a, a, b], or not if they appear as [a, b, a].
+// TODO(adonovan): investigate an algebraic approach to imports;
+// that is, for fixes to Go source files, convert changes within the
+// import(...) portion of the file into semantic edits, compose those
+// edits algebraically, then convert the result back to edits.
+//
+// applyFixes returns success if all fixes are valid, could be cleanly
+// merged, and the corresponding files were successfully updated.
+//
+// If printDiff (from the -diff flag) is set, instead of updating the
+// files it display the final patch composed of all the cleanly merged
+// fixes. (It is tempting to factor printDiff as just a variant of
+// writeFile that is provided the old and new content, but it's hard
+// to generate a good summary that way.)
+//
+// TODO(adonovan): handle file-system level aliases such as symbolic
+// links using robustio.FileID.
+func ApplyFixes(actions []FixAction, writeFile func(filename string, content []byte) error, printDiff, verbose bool) error {
+	generated := make(map[*token.File]bool)
+
+	// Select fixes to apply.
+	//
+	// If there are several for a given Diagnostic, choose the first.
+	// Preserve the order of iteration, for determinism.
+	type fixact struct {
+		fix *analysis.SuggestedFix
+		act FixAction
+	}
+	var fixes []*fixact
+	for _, act := range actions {
+		for _, file := range act.Files {
+			tokFile := act.FileSet.File(file.FileStart)
+			// Memoize, since there may be many actions
+			// for the same package (list of files).
+			if _, seen := generated[tokFile]; !seen {
+				generated[tokFile] = ast.IsGenerated(file)
+			}
+		}
+
+		for _, diag := range act.Diagnostics {
+			for i := range diag.SuggestedFixes {
+				fix := &diag.SuggestedFixes[i]
+				if i == 0 {
+					fixes = append(fixes, &fixact{fix, act})
+				} else {
+					// TODO(adonovan): abstract the logger.
+					log.Printf("%s: ignoring alternative fix %q", act.Name, fix.Message)
+				}
+			}
+		}
+	}
+
+	// Read file content on demand, from the virtual
+	// file system that fed the analyzer (see #62292).
+	//
+	// This cache assumes that all successful reads for the same
+	// file name return the same content.
+	// (It is tempting to group fixes by package and do the
+	// merge/apply/format steps one package at a time, but
+	// packages are not disjoint, due to test variants, so this
+	// would not really address the issue.)
+	baselineContent := make(map[string][]byte)
+	getBaseline := func(readFile ReadFileFunc, filename string) ([]byte, error) {
+		content, ok := baselineContent[filename]
+		if !ok {
+			var err error
+			content, err = readFile(filename)
+			if err != nil {
+				return nil, err
+			}
+			baselineContent[filename] = content
+		}
+		return content, nil
+	}
+
+	// Apply each fix, updating the current state
+	// only if the entire fix can be cleanly merged.
+	var (
+		accumulatedEdits = make(map[string][]diff.Edit)
+		filePkgs         = make(map[string]*types.Package) // maps each file to an arbitrary package that includes it
+
+		goodFixes    = 0 // number of fixes cleanly applied
+		skippedFixes = 0 // number of fixes skipped (because e.g. edits a generated file)
+	)
+fixloop:
+	for _, fixact := range fixes {
+		// Skip a fix if any of its edits touch a generated file.
+		for _, edit := range fixact.fix.TextEdits {
+			file := fixact.act.FileSet.File(edit.Pos)
+			if generated[file] {
+				skippedFixes++
+				continue fixloop
+			}
+		}
+
+		// Convert analysis.TextEdits to diff.Edits, grouped by file.
+		// Precondition: a prior call to validateFix succeeded.
+		fileEdits := make(map[string][]diff.Edit)
+		for _, edit := range fixact.fix.TextEdits {
+			file := fixact.act.FileSet.File(edit.Pos)
+
+			filePkgs[file.Name()] = fixact.act.Pkg
+
+			baseline, err := getBaseline(fixact.act.ReadFileFunc, file.Name())
+			if err != nil {
+				log.Printf("skipping fix to file %s: %v", file.Name(), err)
+				continue fixloop
+			}
+
+			// We choose to treat size mismatch as a serious error,
+			// as it indicates a concurrent write to at least one file,
+			// and possibly others (consider a git checkout, for example).
+			if file.Size() != len(baseline) {
+				return fmt.Errorf("concurrent file modification detected in file %s (size changed from %d -> %d bytes); aborting fix",
+					file.Name(), file.Size(), len(baseline))
+			}
+
+			fileEdits[file.Name()] = append(fileEdits[file.Name()], diff.Edit{
+				Start: file.Offset(edit.Pos),
+				End:   file.Offset(edit.End),
+				New:   string(edit.NewText),
+			})
+		}
+
+		// Apply each set of edits by merging atop
+		// the previous accumulated state.
+		after := make(map[string][]diff.Edit)
+		for file, edits := range fileEdits {
+			if prev := accumulatedEdits[file]; len(prev) > 0 {
+				merged, ok := diff.Merge(prev, edits)
+				if !ok {
+					// debugging
+					if false {
+						log.Printf("%s: fix %s conflicts", fixact.act.Name, fixact.fix.Message)
+					}
+					continue fixloop // conflict
+				}
+				edits = merged
+			}
+			after[file] = edits
+		}
+
+		// The entire fix applied cleanly; commit it.
+		goodFixes++
+		maps.Copy(accumulatedEdits, after)
+		// debugging
+		if false {
+			log.Printf("%s: fix %s applied", fixact.act.Name, fixact.fix.Message)
+		}
+	}
+	badFixes := len(fixes) - goodFixes - skippedFixes // number of fixes that could not be applied
+
+	// Show diff or update files to final state.
+	var files []string
+	for file := range accumulatedEdits {
+		files = append(files, file)
+	}
+	sort.Strings(files) // for deterministic -diff
+	var filesUpdated, totalFiles int
+	for _, file := range files {
+		edits := accumulatedEdits[file]
+		if len(edits) == 0 {
+			continue // the diffs annihilated (a miracle?)
+		}
+
+		// Apply accumulated fixes.
+		baseline := baselineContent[file] // (cache hit)
+		final, err := diff.ApplyBytes(baseline, edits)
+		if err != nil {
+			log.Fatalf("internal error in diff.ApplyBytes: %v", err)
+		}
+
+		// Attempt to format each file.
+		if formatted, err := FormatSourceRemoveImports(filePkgs[file], final); err == nil {
+			final = formatted
+		}
+
+		if printDiff {
+			// Since we formatted the file, we need to recompute the diff.
+			unified := diff.Unified(file+" (old)", file+" (new)", string(baseline), string(final))
+			// TODO(adonovan): abstract the I/O.
+			os.Stdout.WriteString(unified)
+
+		} else {
+			// write file
+			totalFiles++
+			if err := writeFile(file, final); err != nil {
+				log.Println(err)
+				continue // (causes ApplyFix to return an error)
+			}
+			filesUpdated++
+		}
+	}
+
+	// TODO(adonovan): consider returning a structured result that
+	// maps each SuggestedFix to its status:
+	// - invalid
+	// - secondary, not selected
+	// - applied
+	// - had conflicts.
+	// and a mapping from each affected file to:
+	// - its final/original content pair, and
+	// - whether formatting was successful.
+	// Then file writes and the UI can be applied by the caller
+	// in whatever form they like.
+
+	// If victory was incomplete, report an error that indicates partial progress.
+	//
+	// badFixes > 0 indicates that we decided not to attempt some
+	// fixes due to conflicts or failure to read the source; still
+	// it's a relatively benign situation since the user can
+	// re-run the tool, and we may still make progress.
+	//
+	// filesUpdated < totalFiles indicates that some file updates
+	// failed. This should be rare, but is a serious error as it
+	// may apply half a fix, or leave the files in a bad state.
+	//
+	// These numbers are potentially misleading:
+	// The denominator includes duplicate conflicting fixes due to
+	// common files in packages "p" and "p [p.test]", which may
+	// have been fixed and won't appear in the re-run.
+	// TODO(adonovan): eliminate identical fixes as an initial
+	// filtering step.
+	//
+	// TODO(adonovan): should we log that n files were updated in case of total victory?
+	if badFixes > 0 || filesUpdated < totalFiles {
+		if printDiff {
+			return fmt.Errorf("%d of %s skipped (e.g. due to conflicts)",
+				badFixes,
+				plural(len(fixes), "fix", "fixes"))
+		} else {
+			return fmt.Errorf("applied %d of %s; %s updated. (Re-run the command to apply more.)",
+				goodFixes,
+				plural(len(fixes), "fix", "fixes"),
+				plural(filesUpdated, "file", "files"))
+		}
+	}
+
+	if verbose {
+		if skippedFixes > 0 {
+			log.Printf("skipped %s that would edit generated files",
+				plural(skippedFixes, "fix", "fixes"))
+		}
+		log.Printf("applied %s, updated %s",
+			plural(len(fixes), "fix", "fixes"),
+			plural(filesUpdated, "file", "files"))
+	}
+
+	return nil
+}
+
+// FormatSourceRemoveImports is a variant of [format.Source] that
+// removes imports that became redundant when fixes were applied.
+//
+// Import removal is necessarily heuristic since we do not have type
+// information for the fixed file and thus cannot accurately tell
+// whether k is among the free names of T{k: 0}, which requires
+// knowledge of whether T is a struct type.
+//
+// Like [imports.Process] (the core of x/tools/cmd/goimports), it also
+// merges import decls.
+func FormatSourceRemoveImports(pkg *types.Package, src []byte) ([]byte, error) {
+	// This function was reduced from the "strict entire file"
+	// path through [format.Source].
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "fixed.go", src, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+
+	ast.SortImports(fset, file)
+
+	removeUnneededImports(fset, pkg, file)
+
+	// TODO(adonovan): to generate cleaner edits when adding an import,
+	// consider adding a call to imports.mergeImports; however, it does
+	// cause comments to migrate.
+
+	// printerNormalizeNumbers means to canonicalize number literal prefixes
+	// and exponents while printing. See https://golang.org/doc/go1.13#gofmt.
+	//
+	// This value is defined in go/printer specifically for go/format and cmd/gofmt.
+	const printerNormalizeNumbers = 1 << 30
+	cfg := &printer.Config{
+		Mode:     printer.UseSpaces | printer.TabIndent | printerNormalizeNumbers,
+		Tabwidth: 8,
+	}
+	var buf bytes.Buffer
+	if err := cfg.Fprint(&buf, fset, file); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// removeUnneededImports removes import specs that are not referenced
+// within the fixed file. It uses [free.Names] to heuristically
+// approximate the set of imported names needed by the body of the
+// file based only on syntax.
+//
+// pkg provides type information about the unmodified package, in
+// particular the name that would implicitly be declared by a
+// non-renaming import of a given existing dependency.
+func removeUnneededImports(fset *token.FileSet, pkg *types.Package, file *ast.File) {
+	// Map each existing dependency and its transitive dependencies to its default import name.
+	// (We'll need this to interpret non-renaming imports.)
+	packageNames := make(map[string]string)
+	var visit func(pkg *types.Package)
+	visit = func(pkg *types.Package) {
+		if packageNames[pkg.Path()] == "" {
+			packageNames[pkg.Path()] = pkg.Name()
+			for _, imp := range pkg.Imports() {
+				visit(imp)
+			}
+		}
+	}
+	for _, imp := range pkg.Imports() {
+		visit(imp)
+	}
+
+	// Compute the set of free names of the file,
+	// ignoring its import decls.
+	freenames := make(map[string]bool)
+	for _, decl := range file.Decls {
+		if decl, ok := decl.(*ast.GenDecl); ok && decl.Tok == token.IMPORT {
+			continue // skip import
+		}
+
+		// TODO(adonovan): we could do better than includeComplitIdents=false
+		// since we have type information about the unmodified package,
+		// which is a good source of heuristics.
+		const includeComplitIdents = false
+		maps.Copy(freenames, free.Names(decl, includeComplitIdents))
+	}
+
+	// Check whether each import's declared name is free (referenced) by the file.
+	var deletions []func()
+	for _, spec := range file.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue //  malformed import; ignore
+		}
+		explicit := "" // explicit PkgName, if any
+		if spec.Name != nil {
+			explicit = spec.Name.Name
+		}
+		name := explicit // effective PkgName
+		if name == "" {
+			// Non-renaming import: use package's default name.
+			name = packageNames[path]
+		}
+		switch name {
+		case "":
+			continue // assume it's a new import, and we didn't find its default name while searching the import graph
+		case ".":
+			continue // dot imports are tricky
+		case "_":
+			continue // keep blank imports
+		}
+		if !freenames[name] {
+			// Import's effective name is not free in (not used by) the file.
+			// Enqueue it for deletion after the loop.
+			deletions = append(deletions, func() {
+				astutil.DeleteNamedImport(fset, file, explicit, path)
+			})
+		}
+	}
+
+	// Apply the deletions.
+	for _, del := range deletions {
+		del()
+	}
+}
+
+// plural returns "n nouns", selecting the plural form as approriate.
+func plural(n int, singular, plural string) string {
+	if n == 1 {
+		return "1 " + singular
+	} else {
+		return fmt.Sprintf("%d %s", n, plural)
+	}
+}

--- a/vendor/golang.org/x/tools/internal/analysis/driverutil/print.go
+++ b/vendor/golang.org/x/tools/internal/analysis/driverutil/print.go
@@ -1,0 +1,162 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package driverutil
+
+// This file defined output helpers common to all drivers.
+
+import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+	"go/token"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// TODO(adonovan): don't accept an io.Writer if we don't report errors.
+// Either accept a bytes.Buffer (infallible), or return a []byte.
+
+// PrintPlain prints a diagnostic in plain text form.
+// If contextLines is nonnegative, it also prints the
+// offending line plus this many lines of context.
+func PrintPlain(out io.Writer, fset *token.FileSet, contextLines int, diag analysis.Diagnostic) {
+	print := func(pos, end token.Pos, message string) {
+		posn := fset.Position(pos)
+		fmt.Fprintf(out, "%s: %s\n", posn, message)
+
+		// show offending line plus N lines of context.
+		if contextLines >= 0 {
+			end := fset.Position(end)
+			if !end.IsValid() {
+				end = posn
+			}
+			// TODO(adonovan): highlight the portion of the line indicated
+			// by pos...end using ASCII art, terminal colors, etc?
+			data, _ := os.ReadFile(posn.Filename)
+			lines := strings.Split(string(data), "\n")
+			for i := posn.Line - contextLines; i <= end.Line+contextLines; i++ {
+				if 1 <= i && i <= len(lines) {
+					fmt.Fprintf(out, "%d\t%s\n", i, lines[i-1])
+				}
+			}
+		}
+	}
+
+	print(diag.Pos, diag.End, diag.Message)
+	for _, rel := range diag.Related {
+		print(rel.Pos, rel.End, "\t"+rel.Message)
+	}
+}
+
+// A JSONTree is a mapping from package ID to analysis name to result.
+// Each result is either a jsonError or a list of JSONDiagnostic.
+type JSONTree map[string]map[string]any
+
+// A TextEdit describes the replacement of a portion of a file.
+// Start and End are zero-based half-open indices into the original byte
+// sequence of the file, and New is the new text.
+type JSONTextEdit struct {
+	Filename string `json:"filename"`
+	Start    int    `json:"start"`
+	End      int    `json:"end"`
+	New      string `json:"new"`
+}
+
+// A JSONSuggestedFix describes an edit that should be applied as a whole or not
+// at all. It might contain multiple TextEdits/text_edits if the SuggestedFix
+// consists of multiple non-contiguous edits.
+type JSONSuggestedFix struct {
+	Message string         `json:"message"`
+	Edits   []JSONTextEdit `json:"edits"`
+}
+
+// A JSONDiagnostic describes the JSON schema of an analysis.Diagnostic.
+type JSONDiagnostic struct {
+	Category       string                   `json:"category,omitempty"`
+	Posn           string                   `json:"posn"` // e.g. "file.go:line:column"
+	End            string                   `json:"end"`  // (ditto)
+	Message        string                   `json:"message"`
+	SuggestedFixes []JSONSuggestedFix       `json:"suggested_fixes,omitempty"`
+	Related        []JSONRelatedInformation `json:"related,omitempty"`
+}
+
+// A JSONRelated describes a secondary position and message related to
+// a primary diagnostic.
+type JSONRelatedInformation struct {
+	Posn    string `json:"posn"` // e.g. "file.go:line:column"
+	End     string `json:"end"`  // (ditto)
+	Message string `json:"message"`
+}
+
+// Add adds the result of analysis 'name' on package 'id'.
+// The result is either a list of diagnostics or an error.
+func (tree JSONTree) Add(fset *token.FileSet, id, name string, diags []analysis.Diagnostic, err error) {
+	var v any
+	if err != nil {
+		type jsonError struct {
+			Err string `json:"error"`
+		}
+		v = jsonError{err.Error()}
+	} else if len(diags) > 0 {
+		diagnostics := make([]JSONDiagnostic, 0, len(diags))
+		for _, f := range diags {
+			var fixes []JSONSuggestedFix
+			for _, fix := range f.SuggestedFixes {
+				var edits []JSONTextEdit
+				for _, edit := range fix.TextEdits {
+					edits = append(edits, JSONTextEdit{
+						Filename: fset.Position(edit.Pos).Filename,
+						Start:    fset.Position(edit.Pos).Offset,
+						End:      fset.Position(edit.End).Offset,
+						New:      string(edit.NewText),
+					})
+				}
+				fixes = append(fixes, JSONSuggestedFix{
+					Message: fix.Message,
+					Edits:   edits,
+				})
+			}
+			var related []JSONRelatedInformation
+			for _, r := range f.Related {
+				related = append(related, JSONRelatedInformation{
+					Posn:    fset.Position(r.Pos).String(),
+					End:     fset.Position(cmp.Or(r.End, r.Pos)).String(),
+					Message: r.Message,
+				})
+			}
+			jdiag := JSONDiagnostic{
+				Category:       f.Category,
+				Posn:           fset.Position(f.Pos).String(),
+				End:            fset.Position(cmp.Or(f.End, f.Pos)).String(),
+				Message:        f.Message,
+				SuggestedFixes: fixes,
+				Related:        related,
+			}
+			diagnostics = append(diagnostics, jdiag)
+		}
+		v = diagnostics
+	}
+	if v != nil {
+		m, ok := tree[id]
+		if !ok {
+			m = make(map[string]any)
+			tree[id] = m
+		}
+		m[name] = v
+	}
+}
+
+func (tree JSONTree) Print(out io.Writer) error {
+	data, err := json.MarshalIndent(tree, "", "\t")
+	if err != nil {
+		log.Panicf("internal error: JSON marshaling failed: %v", err)
+	}
+	_, err = fmt.Fprintf(out, "%s\n", data)
+	return err
+}

--- a/vendor/golang.org/x/tools/internal/analysis/driverutil/readfile.go
+++ b/vendor/golang.org/x/tools/internal/analysis/driverutil/readfile.go
@@ -1,0 +1,43 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package driverutil
+
+// This file defines helpers for implementing [analysis.Pass.ReadFile].
+
+import (
+	"fmt"
+	"slices"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// A ReadFileFunc is a function that returns the
+// contents of a file, such as [os.ReadFile].
+type ReadFileFunc = func(filename string) ([]byte, error)
+
+// CheckedReadFile returns a wrapper around a Pass.ReadFile
+// function that performs the appropriate checks.
+func CheckedReadFile(pass *analysis.Pass, readFile ReadFileFunc) ReadFileFunc {
+	return func(filename string) ([]byte, error) {
+		if err := CheckReadable(pass, filename); err != nil {
+			return nil, err
+		}
+		return readFile(filename)
+	}
+}
+
+// CheckReadable enforces the access policy defined by the ReadFile field of [analysis.Pass].
+func CheckReadable(pass *analysis.Pass, filename string) error {
+	if slices.Contains(pass.OtherFiles, filename) ||
+		slices.Contains(pass.IgnoredFiles, filename) {
+		return nil
+	}
+	for _, f := range pass.Files {
+		if pass.Fset.File(f.FileStart).Name() == filename {
+			return nil
+		}
+	}
+	return fmt.Errorf("Pass.ReadFile: %s is not among OtherFiles, IgnoredFiles, or names of Files", filename)
+}

--- a/vendor/golang.org/x/tools/internal/analysis/driverutil/url.go
+++ b/vendor/golang.org/x/tools/internal/analysis/driverutil/url.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package driverutil
+
+import (
+	"fmt"
+	"net/url"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// ResolveURL resolves the URL field for a Diagnostic from an Analyzer
+// and returns the URL. See Diagnostic.URL for details.
+func ResolveURL(a *analysis.Analyzer, d analysis.Diagnostic) (string, error) {
+	if d.URL == "" && d.Category == "" && a.URL == "" {
+		return "", nil // do nothing
+	}
+	raw := d.URL
+	if d.URL == "" && d.Category != "" {
+		raw = "#" + d.Category
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid Diagnostic.URL %q: %s", raw, err)
+	}
+	base, err := url.Parse(a.URL)
+	if err != nil {
+		return "", fmt.Errorf("invalid Analyzer.URL %q: %s", a.URL, err)
+	}
+	return base.ResolveReference(u).String(), nil
+}

--- a/vendor/golang.org/x/tools/internal/analysis/driverutil/validatefix.go
+++ b/vendor/golang.org/x/tools/internal/analysis/driverutil/validatefix.go
@@ -1,0 +1,118 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package driverutil
+
+// This file defines the validation of SuggestedFixes.
+
+import (
+	"cmp"
+	"fmt"
+	"go/token"
+	"slices"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// ValidateFixes validates the set of fixes for a single diagnostic.
+// Any error indicates a bug in the originating analyzer.
+//
+// It updates fixes so that fixes[*].End.IsValid().
+//
+// It may be used as part of an analysis driver implementation.
+func ValidateFixes(fset *token.FileSet, a *analysis.Analyzer, fixes []analysis.SuggestedFix) error {
+	fixMessages := make(map[string]bool)
+	for i := range fixes {
+		fix := &fixes[i]
+		if fixMessages[fix.Message] {
+			return fmt.Errorf("analyzer %q suggests two fixes with same Message (%s)", a.Name, fix.Message)
+		}
+		fixMessages[fix.Message] = true
+		if err := validateFix(fset, fix); err != nil {
+			return fmt.Errorf("analyzer %q suggests invalid fix (%s): %v", a.Name, fix.Message, err)
+		}
+	}
+	return nil
+}
+
+// validateFix validates a single fix.
+// Any error indicates a bug in the originating analyzer.
+//
+// It updates fix so that fix.End.IsValid().
+func validateFix(fset *token.FileSet, fix *analysis.SuggestedFix) error {
+
+	// Stably sort edits by Pos. This ordering puts insertions
+	// (end = start) before deletions (end > start) at the same
+	// point, but uses a stable sort to preserve the order of
+	// multiple insertions at the same point.
+	slices.SortStableFunc(fix.TextEdits, func(x, y analysis.TextEdit) int {
+		if sign := cmp.Compare(x.Pos, y.Pos); sign != 0 {
+			return sign
+		}
+		return cmp.Compare(x.End, y.End)
+	})
+
+	var prev *analysis.TextEdit
+	for i := range fix.TextEdits {
+		edit := &fix.TextEdits[i]
+
+		// Validate edit individually.
+		start := edit.Pos
+		file := fset.File(start)
+		if file == nil {
+			return fmt.Errorf("no token.File for TextEdit.Pos (%v)", edit.Pos)
+		}
+		fileEnd := token.Pos(file.Base() + file.Size())
+		if end := edit.End; end.IsValid() {
+			if end < start {
+				return fmt.Errorf("TextEdit.Pos (%v) > TextEdit.End (%v)", edit.Pos, edit.End)
+			}
+			endFile := fset.File(end)
+			if endFile != file && end < fileEnd+10 {
+				// Relax the checks below in the special case when the end position
+				// is only slightly beyond EOF, as happens when End is computed
+				// (as in ast.{Struct,Interface}Type) rather than based on
+				// actual token positions. In such cases, truncate end to EOF.
+				//
+				// This is a workaround for #71659; see:
+				// https://github.com/golang/go/issues/71659#issuecomment-2651606031
+				// A better fix would be more faithful recording of token
+				// positions (or their absence) in the AST.
+				edit.End = fileEnd
+				continue
+			}
+			if endFile == nil {
+				return fmt.Errorf("no token.File for TextEdit.End (%v; File(start).FileEnd is %d)", end, file.Base()+file.Size())
+			}
+			if endFile != file {
+				return fmt.Errorf("edit #%d spans files (%v and %v)",
+					i, file.Position(edit.Pos), endFile.Position(edit.End))
+			}
+		} else {
+			edit.End = start // update the SuggestedFix
+		}
+		if eof := fileEnd; edit.End > eof {
+			return fmt.Errorf("end is (%v) beyond end of file (%v)", edit.End, eof)
+		}
+
+		// Validate the sequence of edits:
+		// properly ordered, no overlapping deletions
+		if prev != nil && edit.Pos < prev.End {
+			xpos := fset.Position(prev.Pos)
+			xend := fset.Position(prev.End)
+			ypos := fset.Position(edit.Pos)
+			yend := fset.Position(edit.End)
+			return fmt.Errorf("overlapping edits to %s (%d:%d-%d:%d and %d:%d-%d:%d)",
+				xpos.Filename,
+				xpos.Line, xpos.Column,
+				xend.Line, xend.Column,
+				ypos.Line, ypos.Column,
+				yend.Line, yend.Column,
+			)
+		}
+		prev = edit
+	}
+
+	return nil
+}

--- a/vendor/golang.org/x/tools/internal/astutil/free/free.go
+++ b/vendor/golang.org/x/tools/internal/astutil/free/free.go
@@ -1,0 +1,418 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package free defines utilities for computing the free variables of
+// a syntax tree without type information. This is inherently
+// heuristic because of the T{f: x} ambiguity, in which f may or may
+// not be a lexical reference depending on whether T is a struct type.
+package free
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// Copied, with considerable changes, from go/parser/resolver.go
+// at af53bd2c03.
+
+// Names computes an approximation to the set of free names of the AST
+// at node n based solely on syntax.
+//
+// In the absence of composite literals, the set of free names is exact. Composite
+// literals introduce an ambiguity that can only be resolved with type information:
+// whether F is a field name or a value in `T{F: ...}`.
+// If includeComplitIdents is true, this function conservatively assumes
+// T is not a struct type, so freeishNames overapproximates: the resulting
+// set may contain spurious entries that are not free lexical references
+// but are references to struct fields.
+// If includeComplitIdents is false, this function assumes that T *is*
+// a struct type, so freeishNames underapproximates: the resulting set
+// may omit names that are free lexical references.
+//
+// TODO(adonovan): includeComplitIdents is a crude hammer: the caller
+// may have partial or heuristic information about whether a given T
+// is struct type. Replace includeComplitIdents with a hook to query
+// the caller.
+//
+// The code is based on go/parser.resolveFile, but heavily simplified. Crucial
+// differences are:
+//   - Instead of resolving names to their objects, this function merely records
+//     whether they are free.
+//   - Labels are ignored: they do not refer to values.
+//   - This is never called on ImportSpecs, so the function panics if it sees one.
+func Names(n ast.Node, includeComplitIdents bool) map[string]bool {
+	v := &freeVisitor{
+		free:                 make(map[string]bool),
+		includeComplitIdents: includeComplitIdents,
+	}
+	// Begin with a scope, even though n might not be a form that establishes a scope.
+	// For example, n might be:
+	//    x := ...
+	// Then we need to add the first x to some scope.
+	v.openScope()
+	ast.Walk(v, n)
+	v.closeScope()
+	if v.scope != nil {
+		panic("unbalanced scopes")
+	}
+	return v.free
+}
+
+// A freeVisitor holds state for a free-name analysis.
+type freeVisitor struct {
+	scope                *scope          // the current innermost scope
+	free                 map[string]bool // free names seen so far
+	includeComplitIdents bool            // include identifier key in composite literals
+}
+
+// scope contains all the names defined in a lexical scope.
+// It is like ast.Scope, but without deprecation warnings.
+type scope struct {
+	names map[string]bool
+	outer *scope
+}
+
+func (s *scope) defined(name string) bool {
+	for ; s != nil; s = s.outer {
+		if s.names[name] {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *freeVisitor) Visit(n ast.Node) ast.Visitor {
+	switch n := n.(type) {
+
+	// Expressions.
+	case *ast.Ident:
+		v.use(n)
+
+	case *ast.FuncLit:
+		v.openScope()
+		defer v.closeScope()
+		v.walkFuncType(nil, n.Type)
+		v.walkBody(n.Body)
+
+	case *ast.SelectorExpr:
+		v.walk(n.X)
+		// Skip n.Sel: it cannot be free.
+
+	case *ast.StructType:
+		v.openScope()
+		defer v.closeScope()
+		v.walkFieldList(n.Fields)
+
+	case *ast.FuncType:
+		v.openScope()
+		defer v.closeScope()
+		v.walkFuncType(nil, n)
+
+	case *ast.CompositeLit:
+		v.walk(n.Type)
+		for _, e := range n.Elts {
+			if kv, _ := e.(*ast.KeyValueExpr); kv != nil {
+				if ident, _ := kv.Key.(*ast.Ident); ident != nil {
+					// It is not possible from syntax alone to know whether
+					// an identifier used as a composite literal key is
+					// a struct field (if n.Type is a struct) or a value
+					// (if n.Type is a map, slice or array).
+					if v.includeComplitIdents {
+						// Over-approximate by treating both cases as potentially
+						// free names.
+						v.use(ident)
+					} else {
+						// Under-approximate by ignoring potentially free names.
+					}
+				} else {
+					v.walk(kv.Key)
+				}
+				v.walk(kv.Value)
+			} else {
+				v.walk(e)
+			}
+		}
+
+	case *ast.InterfaceType:
+		v.openScope()
+		defer v.closeScope()
+		v.walkFieldList(n.Methods)
+
+	// Statements
+	case *ast.AssignStmt:
+		walkSlice(v, n.Rhs)
+		if n.Tok == token.DEFINE {
+			v.shortVarDecl(n.Lhs)
+		} else {
+			walkSlice(v, n.Lhs)
+		}
+
+	case *ast.LabeledStmt:
+		// Ignore labels.
+		v.walk(n.Stmt)
+
+	case *ast.BranchStmt:
+		// Ignore labels.
+
+	case *ast.BlockStmt:
+		v.openScope()
+		defer v.closeScope()
+		walkSlice(v, n.List)
+
+	case *ast.IfStmt:
+		v.openScope()
+		defer v.closeScope()
+		v.walk(n.Init)
+		v.walk(n.Cond)
+		v.walk(n.Body)
+		v.walk(n.Else)
+
+	case *ast.CaseClause:
+		walkSlice(v, n.List)
+		v.openScope()
+		defer v.closeScope()
+		walkSlice(v, n.Body)
+
+	case *ast.SwitchStmt:
+		v.openScope()
+		defer v.closeScope()
+		v.walk(n.Init)
+		v.walk(n.Tag)
+		v.walkBody(n.Body)
+
+	case *ast.TypeSwitchStmt:
+		v.openScope()
+		defer v.closeScope()
+		if n.Init != nil {
+			v.walk(n.Init)
+		}
+		v.walk(n.Assign)
+		// We can use walkBody here because we don't track label scopes.
+		v.walkBody(n.Body)
+
+	case *ast.CommClause:
+		v.openScope()
+		defer v.closeScope()
+		v.walk(n.Comm)
+		walkSlice(v, n.Body)
+
+	case *ast.SelectStmt:
+		v.walkBody(n.Body)
+
+	case *ast.ForStmt:
+		v.openScope()
+		defer v.closeScope()
+		v.walk(n.Init)
+		v.walk(n.Cond)
+		v.walk(n.Post)
+		v.walk(n.Body)
+
+	case *ast.RangeStmt:
+		v.openScope()
+		defer v.closeScope()
+		v.walk(n.X)
+		var lhs []ast.Expr
+		if n.Key != nil {
+			lhs = append(lhs, n.Key)
+		}
+		if n.Value != nil {
+			lhs = append(lhs, n.Value)
+		}
+		if len(lhs) > 0 {
+			if n.Tok == token.DEFINE {
+				v.shortVarDecl(lhs)
+			} else {
+				walkSlice(v, lhs)
+			}
+		}
+		v.walk(n.Body)
+
+	// Declarations
+	case *ast.GenDecl:
+		switch n.Tok {
+		case token.CONST, token.VAR:
+			for _, spec := range n.Specs {
+				spec := spec.(*ast.ValueSpec)
+				walkSlice(v, spec.Values)
+				v.walk(spec.Type)
+				v.declare(spec.Names...)
+			}
+
+		case token.TYPE:
+			for _, spec := range n.Specs {
+				spec := spec.(*ast.TypeSpec)
+				// Go spec: The scope of a type identifier declared inside a
+				// function begins at the identifier in the TypeSpec and ends
+				// at the end of the innermost containing block.
+				v.declare(spec.Name)
+				if spec.TypeParams != nil {
+					v.openScope()
+					defer v.closeScope()
+					v.walkTypeParams(spec.TypeParams)
+				}
+				v.walk(spec.Type)
+			}
+
+		case token.IMPORT:
+			panic("encountered import declaration in free analysis")
+		}
+
+	case *ast.FuncDecl:
+		if n.Recv == nil && n.Name.Name != "init" { // package-level function
+			v.declare(n.Name)
+		}
+		v.openScope()
+		defer v.closeScope()
+		v.walkTypeParams(n.Type.TypeParams)
+		v.walkFuncType(n.Recv, n.Type)
+		v.walkBody(n.Body)
+
+	default:
+		return v
+	}
+
+	return nil
+}
+
+func (v *freeVisitor) openScope() {
+	v.scope = &scope{map[string]bool{}, v.scope}
+}
+
+func (v *freeVisitor) closeScope() {
+	v.scope = v.scope.outer
+}
+
+func (v *freeVisitor) walk(n ast.Node) {
+	if n != nil {
+		ast.Walk(v, n)
+	}
+}
+
+func (v *freeVisitor) walkFuncType(recv *ast.FieldList, typ *ast.FuncType) {
+	// First use field types...
+	v.walkRecvFieldType(recv)
+	v.walkFieldTypes(typ.Params)
+	v.walkFieldTypes(typ.Results)
+
+	// ...then declare field names.
+	v.declareFieldNames(recv)
+	v.declareFieldNames(typ.Params)
+	v.declareFieldNames(typ.Results)
+}
+
+// A receiver field is not like a param or result field because
+// "func (recv R[T]) method()" uses R but declares T.
+func (v *freeVisitor) walkRecvFieldType(list *ast.FieldList) {
+	if list == nil {
+		return
+	}
+	for _, f := range list.List { // valid => len=1
+		typ := f.Type
+		if ptr, ok := typ.(*ast.StarExpr); ok {
+			typ = ptr.X
+		}
+
+		// Analyze receiver type as Base[Index, ...]
+		var (
+			base    ast.Expr
+			indices []ast.Expr
+		)
+		switch typ := typ.(type) {
+		case *ast.IndexExpr: // B[T]
+			base, indices = typ.X, []ast.Expr{typ.Index}
+		case *ast.IndexListExpr: // B[K, V]
+			base, indices = typ.X, typ.Indices
+		default: // B
+			base = typ
+		}
+		for _, expr := range indices {
+			if id, ok := expr.(*ast.Ident); ok {
+				v.declare(id)
+			}
+		}
+		v.walk(base)
+	}
+}
+
+// walkTypeParams is like walkFieldList, but declares type parameters eagerly so
+// that they may be resolved in the constraint expressions held in the field
+// Type.
+func (v *freeVisitor) walkTypeParams(list *ast.FieldList) {
+	v.declareFieldNames(list)
+	v.walkFieldTypes(list) // constraints
+}
+
+func (v *freeVisitor) walkBody(body *ast.BlockStmt) {
+	if body == nil {
+		return
+	}
+	walkSlice(v, body.List)
+}
+
+func (v *freeVisitor) walkFieldList(list *ast.FieldList) {
+	if list == nil {
+		return
+	}
+	v.walkFieldTypes(list)    // .Type may contain references
+	v.declareFieldNames(list) // .Names declares names
+}
+
+func (v *freeVisitor) shortVarDecl(lhs []ast.Expr) {
+	// Go spec: A short variable declaration may redeclare variables provided
+	// they were originally declared in the same block with the same type, and
+	// at least one of the non-blank variables is new.
+	//
+	// However, it doesn't matter to free analysis whether a variable is declared
+	// fresh or redeclared.
+	for _, x := range lhs {
+		// In a well-formed program each expr must be an identifier,
+		// but be forgiving.
+		if id, ok := x.(*ast.Ident); ok {
+			v.declare(id)
+		}
+	}
+}
+
+func walkSlice[S ~[]E, E ast.Node](r *freeVisitor, list S) {
+	for _, e := range list {
+		r.walk(e)
+	}
+}
+
+// walkFieldTypes resolves the types of the walkFieldTypes in list.
+// The companion method declareFieldList declares the names of the walkFieldTypes.
+func (v *freeVisitor) walkFieldTypes(list *ast.FieldList) {
+	if list != nil {
+		for _, f := range list.List {
+			v.walk(f.Type)
+		}
+	}
+}
+
+// declareFieldNames declares the names of the fields in list.
+// (Names in a FieldList always establish new bindings.)
+// The companion method resolveFieldList resolves the types of the fields.
+func (v *freeVisitor) declareFieldNames(list *ast.FieldList) {
+	if list != nil {
+		for _, f := range list.List {
+			v.declare(f.Names...)
+		}
+	}
+}
+
+// use marks ident as free if it is not in scope.
+func (v *freeVisitor) use(ident *ast.Ident) {
+	if s := ident.Name; s != "_" && !v.scope.defined(s) {
+		v.free[s] = true
+	}
+}
+
+// declare adds each non-blank ident to the current scope.
+func (v *freeVisitor) declare(idents ...*ast.Ident) {
+	for _, id := range idents {
+		if id.Name != "_" {
+			v.scope.names[id.Name] = true
+		}
+	}
+}

--- a/vendor/golang.org/x/tools/internal/diff/diff.go
+++ b/vendor/golang.org/x/tools/internal/diff/diff.go
@@ -1,0 +1,177 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package diff computes differences between text files or strings.
+package diff
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// An Edit describes the replacement of a portion of a text file.
+type Edit struct {
+	Start, End int    // byte offsets of the region to replace
+	New        string // the replacement
+}
+
+func (e Edit) String() string {
+	return fmt.Sprintf("{Start:%d,End:%d,New:%q}", e.Start, e.End, e.New)
+}
+
+// Apply applies a sequence of edits to the src buffer and returns the
+// result. Edits are applied in order of start offset; edits with the
+// same start offset are applied in they order they were provided.
+//
+// Apply returns an error if any edit is out of bounds,
+// or if any pair of edits is overlapping.
+func Apply(src string, edits []Edit) (string, error) {
+	edits, size, err := validate(src, edits)
+	if err != nil {
+		return "", err
+	}
+
+	// Apply edits.
+	out := make([]byte, 0, size)
+	lastEnd := 0
+	for _, edit := range edits {
+		if lastEnd < edit.Start {
+			out = append(out, src[lastEnd:edit.Start]...)
+		}
+		out = append(out, edit.New...)
+		lastEnd = edit.End
+	}
+	out = append(out, src[lastEnd:]...)
+
+	if len(out) != size {
+		panic("wrong size")
+	}
+
+	return string(out), nil
+}
+
+// ApplyBytes is like Apply, but it accepts a byte slice.
+// The result is always a new array.
+func ApplyBytes(src []byte, edits []Edit) ([]byte, error) {
+	res, err := Apply(string(src), edits)
+	return []byte(res), err
+}
+
+// validate checks that edits are consistent with src,
+// and returns the size of the patched output.
+// It may return a different slice.
+func validate(src string, edits []Edit) ([]Edit, int, error) {
+	if !sort.IsSorted(editsSort(edits)) {
+		edits = slices.Clone(edits)
+		SortEdits(edits)
+	}
+
+	// Check validity of edits and compute final size.
+	size := len(src)
+	lastEnd := 0
+	for _, edit := range edits {
+		if !(0 <= edit.Start && edit.Start <= edit.End && edit.End <= len(src)) {
+			return nil, 0, fmt.Errorf("diff has out-of-bounds edits")
+		}
+		if edit.Start < lastEnd {
+			return nil, 0, fmt.Errorf("diff has overlapping edits")
+		}
+		size += len(edit.New) + edit.Start - edit.End
+		lastEnd = edit.End
+	}
+
+	return edits, size, nil
+}
+
+// SortEdits orders a slice of Edits by (start, end) offset.
+// This ordering puts insertions (end = start) before deletions
+// (end > start) at the same point, but uses a stable sort to preserve
+// the order of multiple insertions at the same point.
+// (Apply detects multiple deletions at the same point as an error.)
+func SortEdits(edits []Edit) {
+	sort.Stable(editsSort(edits))
+}
+
+type editsSort []Edit
+
+func (a editsSort) Len() int { return len(a) }
+func (a editsSort) Less(i, j int) bool {
+	if cmp := a[i].Start - a[j].Start; cmp != 0 {
+		return cmp < 0
+	}
+	return a[i].End < a[j].End
+}
+func (a editsSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+
+// lineEdits expands and merges a sequence of edits so that each
+// resulting edit replaces one or more complete lines.
+// See ApplyEdits for preconditions.
+func lineEdits(src string, edits []Edit) ([]Edit, error) {
+	edits, _, err := validate(src, edits)
+	if err != nil {
+		return nil, err
+	}
+
+	// Do all deletions begin and end at the start of a line,
+	// and all insertions end with a newline?
+	// (This is merely a fast path.)
+	for _, edit := range edits {
+		if edit.Start >= len(src) || // insertion at EOF
+			edit.Start > 0 && src[edit.Start-1] != '\n' || // not at line start
+			edit.End > 0 && src[edit.End-1] != '\n' || // not at line start
+			edit.New != "" && edit.New[len(edit.New)-1] != '\n' { // partial insert
+			goto expand // slow path
+		}
+	}
+	return edits, nil // aligned
+
+expand:
+	if len(edits) == 0 {
+		return edits, nil // no edits (unreachable due to fast path)
+	}
+	expanded := make([]Edit, 0, len(edits)) // a guess
+	prev := edits[0]
+	// TODO(adonovan): opt: start from the first misaligned edit.
+	// TODO(adonovan): opt: avoid quadratic cost of string += string.
+	for _, edit := range edits[1:] {
+		between := src[prev.End:edit.Start]
+		if !strings.Contains(between, "\n") {
+			// overlapping lines: combine with previous edit.
+			prev.New += between + edit.New
+			prev.End = edit.End
+		} else {
+			// non-overlapping lines: flush previous edit.
+			expanded = append(expanded, expandEdit(prev, src))
+			prev = edit
+		}
+	}
+	return append(expanded, expandEdit(prev, src)), nil // flush final edit
+}
+
+// expandEdit returns edit expanded to complete whole lines.
+func expandEdit(edit Edit, src string) Edit {
+	// Expand start left to start of line.
+	// (delta is the zero-based column number of start.)
+	start := edit.Start
+	if delta := start - 1 - strings.LastIndex(src[:start], "\n"); delta > 0 {
+		edit.Start -= delta
+		edit.New = src[start-delta:start] + edit.New
+	}
+
+	// Expand end right to end of line.
+	end := edit.End
+	if end > 0 && src[end-1] != '\n' ||
+		edit.New != "" && edit.New[len(edit.New)-1] != '\n' {
+		if nl := strings.IndexByte(src[end:], '\n'); nl < 0 {
+			edit.End = len(src) // extend to EOF
+		} else {
+			edit.End = end + nl + 1 // extend beyond \n
+		}
+	}
+	edit.New += src[end:edit.End]
+
+	return edit
+}

--- a/vendor/golang.org/x/tools/internal/diff/lcs/common.go
+++ b/vendor/golang.org/x/tools/internal/diff/lcs/common.go
@@ -1,0 +1,179 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package lcs
+
+import (
+	"log"
+	"sort"
+)
+
+// lcs is a longest common sequence
+type lcs []diag
+
+// A diag is a piece of the edit graph where A[X+i] == B[Y+i], for 0<=i<Len.
+// All computed diagonals are parts of a longest common subsequence.
+type diag struct {
+	X, Y int
+	Len  int
+}
+
+// sort sorts in place, by lowest X, and if tied, inversely by Len
+func (l lcs) sort() lcs {
+	sort.Slice(l, func(i, j int) bool {
+		if l[i].X != l[j].X {
+			return l[i].X < l[j].X
+		}
+		return l[i].Len > l[j].Len
+	})
+	return l
+}
+
+// validate that the elements of the lcs do not overlap
+// (can only happen when the two-sided algorithm ends early)
+// expects the lcs to be sorted
+func (l lcs) valid() bool {
+	for i := 1; i < len(l); i++ {
+		if l[i-1].X+l[i-1].Len > l[i].X {
+			return false
+		}
+		if l[i-1].Y+l[i-1].Len > l[i].Y {
+			return false
+		}
+	}
+	return true
+}
+
+// repair overlapping lcs
+// only called if two-sided stops early
+func (l lcs) fix() lcs {
+	// from the set of diagonals in l, find a maximal non-conflicting set
+	// this problem may be NP-complete, but we use a greedy heuristic,
+	// which is quadratic, but with a better data structure, could be D log D.
+	// independent is not enough: {0,3,1} and {3,0,2} can't both occur in an lcs
+	// which has to have monotone x and y
+	if len(l) == 0 {
+		return nil
+	}
+	sort.Slice(l, func(i, j int) bool { return l[i].Len > l[j].Len })
+	tmp := make(lcs, 0, len(l))
+	tmp = append(tmp, l[0])
+	for i := 1; i < len(l); i++ {
+		var dir direction
+		nxt := l[i]
+		for _, in := range tmp {
+			if dir, nxt = overlap(in, nxt); dir == empty || dir == bad {
+				break
+			}
+		}
+		if nxt.Len > 0 && dir != bad {
+			tmp = append(tmp, nxt)
+		}
+	}
+	tmp.sort()
+	if false && !tmp.valid() { // debug checking
+		log.Fatalf("here %d", len(tmp))
+	}
+	return tmp
+}
+
+type direction int
+
+const (
+	empty    direction = iota // diag is empty (so not in lcs)
+	leftdown                  // proposed acceptably to the left and below
+	rightup                   // proposed diag is acceptably to the right and above
+	bad                       // proposed diag is inconsistent with the lcs so far
+)
+
+// overlap trims the proposed diag prop  so it doesn't overlap with
+// the existing diag that has already been added to the lcs.
+func overlap(exist, prop diag) (direction, diag) {
+	if prop.X <= exist.X && exist.X < prop.X+prop.Len {
+		// remove the end of prop where it overlaps with the X end of exist
+		delta := prop.X + prop.Len - exist.X
+		prop.Len -= delta
+		if prop.Len <= 0 {
+			return empty, prop
+		}
+	}
+	if exist.X <= prop.X && prop.X < exist.X+exist.Len {
+		// remove the beginning of prop where overlaps with exist
+		delta := exist.X + exist.Len - prop.X
+		prop.Len -= delta
+		if prop.Len <= 0 {
+			return empty, prop
+		}
+		prop.X += delta
+		prop.Y += delta
+	}
+	if prop.Y <= exist.Y && exist.Y < prop.Y+prop.Len {
+		// remove the end of prop that overlaps (in Y) with exist
+		delta := prop.Y + prop.Len - exist.Y
+		prop.Len -= delta
+		if prop.Len <= 0 {
+			return empty, prop
+		}
+	}
+	if exist.Y <= prop.Y && prop.Y < exist.Y+exist.Len {
+		// remove the beginning of peop that overlaps with exist
+		delta := exist.Y + exist.Len - prop.Y
+		prop.Len -= delta
+		if prop.Len <= 0 {
+			return empty, prop
+		}
+		prop.X += delta // no test reaches this code
+		prop.Y += delta
+	}
+	if prop.X+prop.Len <= exist.X && prop.Y+prop.Len <= exist.Y {
+		return leftdown, prop
+	}
+	if exist.X+exist.Len <= prop.X && exist.Y+exist.Len <= prop.Y {
+		return rightup, prop
+	}
+	// prop can't be in an lcs that contains exist
+	return bad, prop
+}
+
+// manipulating Diag and lcs
+
+// prepend a diagonal (x,y)-(x+1,y+1) segment either to an empty lcs
+// or to its first Diag. prepend is only called to extend diagonals
+// the backward direction.
+func (lcs lcs) prepend(x, y int) lcs {
+	if len(lcs) > 0 {
+		d := &lcs[0]
+		if int(d.X) == x+1 && int(d.Y) == y+1 {
+			// extend the diagonal down and to the left
+			d.X, d.Y = int(x), int(y)
+			d.Len++
+			return lcs
+		}
+	}
+
+	r := diag{X: int(x), Y: int(y), Len: 1}
+	lcs = append([]diag{r}, lcs...)
+	return lcs
+}
+
+// append appends a diagonal, or extends the existing one.
+// by adding the edge (x,y)-(x+1.y+1). append is only called
+// to extend diagonals in the forward direction.
+func (lcs lcs) append(x, y int) lcs {
+	if len(lcs) > 0 {
+		last := &lcs[len(lcs)-1]
+		// Expand last element if adjoining.
+		if last.X+last.Len == x && last.Y+last.Len == y {
+			last.Len++
+			return lcs
+		}
+	}
+
+	return append(lcs, diag{X: x, Y: y, Len: 1})
+}
+
+// enforce constraint on d, k
+func ok(d, k int) bool {
+	return d >= 0 && -d <= k && k <= d
+}

--- a/vendor/golang.org/x/tools/internal/diff/lcs/doc.go
+++ b/vendor/golang.org/x/tools/internal/diff/lcs/doc.go
@@ -1,0 +1,156 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// package lcs contains code to find longest-common-subsequences
+// (and diffs)
+package lcs
+
+/*
+Compute longest-common-subsequences of two slices A, B using
+algorithms from Myers' paper. A longest-common-subsequence
+(LCS from now on) of A and B is a maximal set of lexically increasing
+pairs of subscripts (x,y) with A[x]==B[y]. There may be many LCS, but
+they all have the same length. An LCS determines a sequence of edits
+that changes A into B.
+
+The key concept is the edit graph of A and B.
+If A has length N and B has length M, then the edit graph has
+vertices v[i][j] for 0 <= i <= N, 0 <= j <= M. There is a
+horizontal edge from v[i][j] to v[i+1][j] whenever both are in
+the graph, and a vertical edge from v[i][j] to f[i][j+1] similarly.
+When A[i] == B[j] there is a diagonal edge from v[i][j] to v[i+1][j+1].
+
+A path between in the graph between (0,0) and (N,M) determines a sequence
+of edits converting A into B: each horizontal edge corresponds to removing
+an element of A, and each vertical edge corresponds to inserting an
+element of B.
+
+A vertex (x,y) is on (forward) diagonal k if x-y=k. A path in the graph
+is of length D if it has D non-diagonal edges. The algorithms generate
+forward paths (in which at least one of x,y increases at each edge),
+or backward paths (in which at least one of x,y decreases at each edge),
+or a combination. (Note that the orientation is the traditional mathematical one,
+with the origin in the lower-left corner.)
+
+Here is the edit graph for A:"aabbaa", B:"aacaba". (I know the diagonals look weird.)
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙
+   a      |   ___/‾‾‾   |   ___/‾‾‾   |             |             |   ___/‾‾‾   |   ___/‾‾‾   |
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙
+   b      |             |             |   ___/‾‾‾   |   ___/‾‾‾   |             |             |
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙
+   a      |   ___/‾‾‾   |   ___/‾‾‾   |             |             |   ___/‾‾‾   |   ___/‾‾‾   |
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙
+   c      |             |             |             |             |             |             |
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙
+   a      |   ___/‾‾‾   |   ___/‾‾‾   |             |             |   ___/‾‾‾   |   ___/‾‾‾   |
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙
+   a      |   ___/‾‾‾   |   ___/‾‾‾   |             |             |   ___/‾‾‾   |   ___/‾‾‾   |
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙
+                 a             a             b             b             a             a
+
+
+The algorithm labels a vertex (x,y) with D,k if it is on diagonal k and at
+the end of a maximal path of length D. (Because x-y=k it suffices to remember
+only the x coordinate of the vertex.)
+
+The forward algorithm: Find the longest diagonal starting at (0,0) and
+label its end with D=0,k=0. From that vertex take a vertical step and
+then follow the longest diagonal (up and to the right), and label that vertex
+with D=1,k=-1. From the D=0,k=0 point take a horizontal step and the follow
+the longest diagonal (up and to the right) and label that vertex
+D=1,k=1. In the same way, having labelled all the D vertices,
+from a vertex labelled D,k find two vertices
+tentatively labelled D+1,k-1 and D+1,k+1. There may be two on the same
+diagonal, in which case take the one with the larger x.
+
+Eventually the path gets to (N,M), and the diagonals on it are the LCS.
+
+Here is the edit graph with the ends of D-paths labelled. (So, for instance,
+0/2,2 indicates that x=2,y=2 is labelled with 0, as it should be, since the first
+step is to go up the longest diagonal from (0,0).)
+A:"aabbaa", B:"aacaba"
+          ⊙   -------   ⊙   -------   ⊙   -------(3/3,6)-------   ⊙   -------(3/5,6)-------(4/6,6)
+   a      |   ___/‾‾‾   |   ___/‾‾‾   |             |             |   ___/‾‾‾   |   ___/‾‾‾   |
+          ⊙   -------   ⊙   -------   ⊙   -------(2/3,5)-------   ⊙   -------   ⊙   -------   ⊙
+   b      |             |             |   ___/‾‾‾   |   ___/‾‾‾   |             |             |
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------(3/5,4)-------   ⊙
+   a      |   ___/‾‾‾   |   ___/‾‾‾   |             |             |   ___/‾‾‾   |   ___/‾‾‾   |
+          ⊙   -------   ⊙   -------(1/2,3)-------(2/3,3)-------   ⊙   -------   ⊙   -------   ⊙
+   c      |             |             |             |             |             |             |
+          ⊙   -------   ⊙   -------(0/2,2)-------(1/3,2)-------(2/4,2)-------(3/5,2)-------(4/6,2)
+   a      |   ___/‾‾‾   |   ___/‾‾‾   |             |             |   ___/‾‾‾   |   ___/‾‾‾   |
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙
+   a      |   ___/‾‾‾   |   ___/‾‾‾   |             |             |   ___/‾‾‾   |   ___/‾‾‾   |
+          ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙   -------   ⊙
+                 a             a             b             b             a             a
+
+The 4-path is reconstructed starting at (4/6,6), horizontal to (3/5,6), diagonal to (3,4), vertical
+to (2/3,3), horizontal to (1/2,3), vertical to (0/2,2), and diagonal to (0,0). As expected,
+there are 4 non-diagonal steps, and the diagonals form an LCS.
+
+There is a symmetric backward algorithm, which gives (backwards labels are prefixed with a colon):
+A:"aabbaa", B:"aacaba"
+            ⊙   --------    ⊙   --------    ⊙   --------    ⊙   --------    ⊙   --------    ⊙   --------    ⊙
+    a       |   ____/‾‾‾    |   ____/‾‾‾    |               |               |   ____/‾‾‾    |   ____/‾‾‾    |
+            ⊙   --------    ⊙   --------    ⊙   --------    ⊙   --------    ⊙   --------(:0/5,5)--------    ⊙
+    b       |               |               |   ____/‾‾‾    |   ____/‾‾‾    |               |               |
+            ⊙   --------    ⊙   --------    ⊙   --------(:1/3,4)--------    ⊙   --------    ⊙   --------    ⊙
+    a       |   ____/‾‾‾    |   ____/‾‾‾    |               |               |   ____/‾‾‾    |   ____/‾‾‾    |
+        (:3/0,3)--------(:2/1,3)--------    ⊙   --------(:2/3,3)--------(:1/4,3)--------    ⊙   --------    ⊙
+    c       |               |               |               |               |               |               |
+            ⊙   --------    ⊙   --------    ⊙   --------(:3/3,2)--------(:2/4,2)--------    ⊙   --------    ⊙
+    a       |   ____/‾‾‾    |   ____/‾‾‾    |               |               |   ____/‾‾‾    |   ____/‾‾‾    |
+        (:3/0,1)--------    ⊙   --------    ⊙   --------    ⊙   --------(:3/4,1)--------    ⊙   --------    ⊙
+    a       |   ____/‾‾‾    |   ____/‾‾‾    |               |               |   ____/‾‾‾    |   ____/‾‾‾    |
+        (:4/0,0)--------    ⊙   --------    ⊙   --------    ⊙   --------(:4/4,0)--------    ⊙   --------    ⊙
+                    a               a               b               b               a               a
+
+Neither of these is ideal for use in an editor, where it is undesirable to send very long diffs to the
+front end. It's tricky to decide exactly what 'very long diffs' means, as "replace A by B" is very short.
+We want to control how big D can be, by stopping when it gets too large. The forward algorithm then
+privileges common prefixes, and the backward algorithm privileges common suffixes. Either is an undesirable
+asymmetry.
+
+Fortunately there is a two-sided algorithm, implied by results in Myers' paper. Here's what the labels in
+the edit graph look like.
+A:"aabbaa", B:"aacaba"
+             ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙
+    a        |    ____/‾‾‾‾    |    ____/‾‾‾‾    |                 |                 |    ____/‾‾‾‾    |    ____/‾‾‾‾    |
+             ⊙    ---------    ⊙    ---------    ⊙    --------- (2/3,5) ---------    ⊙    --------- (:0/5,5)---------    ⊙
+    b        |                 |                 |    ____/‾‾‾‾    |    ____/‾‾‾‾    |                 |                 |
+             ⊙    ---------    ⊙    ---------    ⊙    --------- (:1/3,4)---------    ⊙    ---------    ⊙    ---------    ⊙
+    a        |    ____/‾‾‾‾    |    ____/‾‾‾‾    |                 |                 |    ____/‾‾‾‾    |    ____/‾‾‾‾    |
+             ⊙    --------- (:2/1,3)--------- (1/2,3) ---------(2:2/3,3)--------- (:1/4,3)---------    ⊙    ---------    ⊙
+    c        |                 |                 |                 |                 |                 |                 |
+             ⊙    ---------    ⊙    --------- (0/2,2) --------- (1/3,2) ---------(2:2/4,2)---------    ⊙    ---------    ⊙
+    a        |    ____/‾‾‾‾    |    ____/‾‾‾‾    |                 |                 |    ____/‾‾‾‾    |    ____/‾‾‾‾    |
+             ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙
+    a        |    ____/‾‾‾‾    |    ____/‾‾‾‾    |                 |                 |    ____/‾‾‾‾    |    ____/‾‾‾‾    |
+             ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙    ---------    ⊙
+                      a                 a                 b                 b                 a                 a
+
+The algorithm stopped when it saw the backwards 2-path ending at (1,3) and the forwards 2-path ending at (3,5). The criterion
+is a backwards path ending at (u,v) and a forward path ending at (x,y), where u <= x and the two points are on the same
+diagonal. (Here the edgegraph has a diagonal, but the criterion is x-y=u-v.) Myers proves there is a forward
+2-path from (0,0) to (1,3), and that together with the backwards 2-path ending at (1,3) gives the expected 4-path.
+Unfortunately the forward path has to be constructed by another run of the forward algorithm; it can't be found from the
+computed labels. That is the worst case. Had the code noticed (x,y)=(u,v)=(3,3) the whole path could be reconstructed
+from the edgegraph. The implementation looks for a number of special cases to try to avoid computing an extra forward path.
+
+If the two-sided algorithm has stop early (because D has become too large) it will have found a forward LCS and a
+backwards LCS. Ideally these go with disjoint prefixes and suffixes of A and B, but disjointedness may fail and the two
+computed LCS may conflict. (An easy example is where A is a suffix of B, and shares a short prefix. The backwards LCS
+is all of A, and the forward LCS is a prefix of A.) The algorithm combines the two
+to form a best-effort LCS. In the worst case the forward partial LCS may have to
+be recomputed.
+*/
+
+/* Eugene Myers paper is titled
+"An O(ND) Difference Algorithm and Its Variations"
+and can be found at
+http://www.xmailserver.org/diff2.pdf
+
+(There is a generic implementation of the algorithm the repository with git hash
+b9ad7e4ade3a686d608e44475390ad428e60e7fc)
+*/

--- a/vendor/golang.org/x/tools/internal/diff/lcs/git.sh
+++ b/vendor/golang.org/x/tools/internal/diff/lcs/git.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2022 The Go Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
+# Creates a zip file containing all numbered versions
+# of the commit history of a large source file, for use
+# as input data for the tests of the diff algorithm.
+#
+# Run script from root of the x/tools repo.
+
+set -eu
+
+# WARNING: This script will install the latest version of $file
+# The largest real source file in the x/tools repo.
+# file=internal/golang/completion/completion.go
+# file=internal/golang/diagnostics.go
+file=internal/protocol/tsprotocol.go
+
+tmp=$(mktemp -d)
+git log $file |
+  awk '/^commit / {print $2}' |
+  nl -ba -nrz |
+  while read n hash; do
+    git checkout --quiet $hash $file
+    cp -f $file $tmp/$n
+  done
+(cd $tmp && zip -q - *) > testdata.zip
+rm -fr $tmp
+git restore --staged $file
+git restore $file
+echo "Created testdata.zip"

--- a/vendor/golang.org/x/tools/internal/diff/lcs/labels.go
+++ b/vendor/golang.org/x/tools/internal/diff/lcs/labels.go
@@ -1,0 +1,55 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package lcs
+
+import (
+	"fmt"
+)
+
+// For each D, vec[D] has length D+1,
+// and the label for (D, k) is stored in vec[D][(D+k)/2].
+type label struct {
+	vec [][]int
+}
+
+// Temporary checking DO NOT COMMIT true TO PRODUCTION CODE
+const debug = false
+
+// debugging. check that the (d,k) pair is valid
+// (that is, -d<=k<=d and d+k even)
+func checkDK(D, k int) {
+	if k >= -D && k <= D && (D+k)%2 == 0 {
+		return
+	}
+	panic(fmt.Sprintf("out of range, d=%d,k=%d", D, k))
+}
+
+func (t *label) set(D, k, x int) {
+	if debug {
+		checkDK(D, k)
+	}
+	for len(t.vec) <= D {
+		t.vec = append(t.vec, nil)
+	}
+	if t.vec[D] == nil {
+		t.vec[D] = make([]int, D+1)
+	}
+	t.vec[D][(D+k)/2] = x // known that D+k is even
+}
+
+func (t *label) get(d, k int) int {
+	if debug {
+		checkDK(d, k)
+	}
+	return int(t.vec[d][(d+k)/2])
+}
+
+func newtriang(limit int) label {
+	if limit < 100 {
+		// Preallocate if limit is not large.
+		return label{vec: make([][]int, limit)}
+	}
+	return label{}
+}

--- a/vendor/golang.org/x/tools/internal/diff/lcs/old.go
+++ b/vendor/golang.org/x/tools/internal/diff/lcs/old.go
@@ -1,0 +1,475 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package lcs
+
+// TODO(adonovan): remove unclear references to "old" in this package.
+
+import (
+	"fmt"
+)
+
+// A Diff is a replacement of a portion of A by a portion of B.
+type Diff struct {
+	Start, End         int // offsets of portion to delete in A
+	ReplStart, ReplEnd int // offset of replacement text in B
+}
+
+// DiffBytes returns the differences between two byte sequences.
+// It does not respect rune boundaries.
+func DiffBytes(a, b []byte) []Diff { return diff(bytesSeqs{a, b}) }
+
+// DiffRunes returns the differences between two rune sequences.
+func DiffRunes(a, b []rune) []Diff { return diff(runesSeqs{a, b}) }
+
+// DiffLines returns the differences between two string sequences.
+func DiffLines(a, b []string) []Diff { return diff(linesSeqs{a, b}) }
+
+// A limit on how deeply the LCS algorithm should search. The value is just a guess.
+var maxDiffs = 100
+
+func diff(seqs sequences) []Diff {
+	diff, _ := compute(seqs, twosided, maxDiffs/2)
+	return diff
+}
+
+// compute computes the list of differences between two sequences,
+// along with the LCS. It is exercised directly by tests.
+// The algorithm is one of {forward, backward, twosided}.
+func compute(seqs sequences, algo func(*editGraph) lcs, limit int) ([]Diff, lcs) {
+	if limit <= 0 {
+		limit = 1 << 25 // effectively infinity
+	}
+	alen, blen := seqs.lengths()
+	g := &editGraph{
+		seqs:  seqs,
+		vf:    newtriang(limit),
+		vb:    newtriang(limit),
+		limit: limit,
+		ux:    alen,
+		uy:    blen,
+		delta: alen - blen,
+	}
+	lcs := algo(g)
+	diffs := lcs.toDiffs(alen, blen)
+	return diffs, lcs
+}
+
+// editGraph carries the information for computing the lcs of two sequences.
+type editGraph struct {
+	seqs   sequences
+	vf, vb label // forward and backward labels
+
+	limit int // maximal value of D
+	// the bounding rectangle of the current edit graph
+	lx, ly, ux, uy int
+	delta          int // common subexpression: (ux-lx)-(uy-ly)
+}
+
+// toDiffs converts an LCS to a list of edits.
+func (lcs lcs) toDiffs(alen, blen int) []Diff {
+	var diffs []Diff
+	var pa, pb int // offsets in a, b
+	for _, l := range lcs {
+		if pa < l.X || pb < l.Y {
+			diffs = append(diffs, Diff{pa, l.X, pb, l.Y})
+		}
+		pa = l.X + l.Len
+		pb = l.Y + l.Len
+	}
+	if pa < alen || pb < blen {
+		diffs = append(diffs, Diff{pa, alen, pb, blen})
+	}
+	return diffs
+}
+
+// --- FORWARD ---
+
+// fdone decides if the forward path has reached the upper right
+// corner of the rectangle. If so, it also returns the computed lcs.
+func (e *editGraph) fdone(D, k int) (bool, lcs) {
+	// x, y, k are relative to the rectangle
+	x := e.vf.get(D, k)
+	y := x - k
+	if x == e.ux && y == e.uy {
+		return true, e.forwardlcs(D, k)
+	}
+	return false, nil
+}
+
+// run the forward algorithm, until success or up to the limit on D.
+func forward(e *editGraph) lcs {
+	e.setForward(0, 0, e.lx)
+	if ok, ans := e.fdone(0, 0); ok {
+		return ans
+	}
+	// from D to D+1
+	for D := range e.limit {
+		e.setForward(D+1, -(D + 1), e.getForward(D, -D))
+		if ok, ans := e.fdone(D+1, -(D + 1)); ok {
+			return ans
+		}
+		e.setForward(D+1, D+1, e.getForward(D, D)+1)
+		if ok, ans := e.fdone(D+1, D+1); ok {
+			return ans
+		}
+		for k := -D + 1; k <= D-1; k += 2 {
+			// these are tricky and easy to get backwards
+			lookv := e.lookForward(k, e.getForward(D, k-1)+1)
+			lookh := e.lookForward(k, e.getForward(D, k+1))
+			if lookv > lookh {
+				e.setForward(D+1, k, lookv)
+			} else {
+				e.setForward(D+1, k, lookh)
+			}
+			if ok, ans := e.fdone(D+1, k); ok {
+				return ans
+			}
+		}
+	}
+	// D is too large
+	// find the D path with maximal x+y inside the rectangle and
+	// use that to compute the found part of the lcs
+	kmax := -e.limit - 1
+	diagmax := -1
+	for k := -e.limit; k <= e.limit; k += 2 {
+		x := e.getForward(e.limit, k)
+		y := x - k
+		if x+y > diagmax && x <= e.ux && y <= e.uy {
+			diagmax, kmax = x+y, k
+		}
+	}
+	return e.forwardlcs(e.limit, kmax)
+}
+
+// recover the lcs by backtracking from the farthest point reached
+func (e *editGraph) forwardlcs(D, k int) lcs {
+	var ans lcs
+	for x := e.getForward(D, k); x != 0 || x-k != 0; {
+		if ok(D-1, k-1) && x-1 == e.getForward(D-1, k-1) {
+			// if (x-1,y) is labelled D-1, x--,D--,k--,continue
+			D, k, x = D-1, k-1, x-1
+			continue
+		} else if ok(D-1, k+1) && x == e.getForward(D-1, k+1) {
+			// if (x,y-1) is labelled D-1, x, D--,k++, continue
+			D, k = D-1, k+1
+			continue
+		}
+		// if (x-1,y-1)--(x,y) is a diagonal, prepend,x--,y--, continue
+		y := x - k
+		ans = ans.prepend(x+e.lx-1, y+e.ly-1)
+		x--
+	}
+	return ans
+}
+
+// start at (x,y), go up the diagonal as far as possible,
+// and label the result with d
+func (e *editGraph) lookForward(k, relx int) int {
+	rely := relx - k
+	x, y := relx+e.lx, rely+e.ly
+	if x < e.ux && y < e.uy {
+		x += e.seqs.commonPrefixLen(x, e.ux, y, e.uy)
+	}
+	return x
+}
+
+func (e *editGraph) setForward(d, k, relx int) {
+	x := e.lookForward(k, relx)
+	e.vf.set(d, k, x-e.lx)
+}
+
+func (e *editGraph) getForward(d, k int) int {
+	x := e.vf.get(d, k)
+	return x
+}
+
+// --- BACKWARD ---
+
+// bdone decides if the backward path has reached the lower left corner
+func (e *editGraph) bdone(D, k int) (bool, lcs) {
+	// x, y, k are relative to the rectangle
+	x := e.vb.get(D, k)
+	y := x - (k + e.delta)
+	if x == 0 && y == 0 {
+		return true, e.backwardlcs(D, k)
+	}
+	return false, nil
+}
+
+// run the backward algorithm, until success or up to the limit on D.
+// (used only by tests)
+func backward(e *editGraph) lcs {
+	e.setBackward(0, 0, e.ux)
+	if ok, ans := e.bdone(0, 0); ok {
+		return ans
+	}
+	// from D to D+1
+	for D := range e.limit {
+		e.setBackward(D+1, -(D + 1), e.getBackward(D, -D)-1)
+		if ok, ans := e.bdone(D+1, -(D + 1)); ok {
+			return ans
+		}
+		e.setBackward(D+1, D+1, e.getBackward(D, D))
+		if ok, ans := e.bdone(D+1, D+1); ok {
+			return ans
+		}
+		for k := -D + 1; k <= D-1; k += 2 {
+			// these are tricky and easy to get wrong
+			lookv := e.lookBackward(k, e.getBackward(D, k-1))
+			lookh := e.lookBackward(k, e.getBackward(D, k+1)-1)
+			if lookv < lookh {
+				e.setBackward(D+1, k, lookv)
+			} else {
+				e.setBackward(D+1, k, lookh)
+			}
+			if ok, ans := e.bdone(D+1, k); ok {
+				return ans
+			}
+		}
+	}
+
+	// D is too large
+	// find the D path with minimal x+y inside the rectangle and
+	// use that to compute the part of the lcs found
+	kmax := -e.limit - 1
+	diagmin := 1 << 25
+	for k := -e.limit; k <= e.limit; k += 2 {
+		x := e.getBackward(e.limit, k)
+		y := x - (k + e.delta)
+		if x+y < diagmin && x >= 0 && y >= 0 {
+			diagmin, kmax = x+y, k
+		}
+	}
+	if kmax < -e.limit {
+		panic(fmt.Sprintf("no paths when limit=%d?", e.limit))
+	}
+	return e.backwardlcs(e.limit, kmax)
+}
+
+// recover the lcs by backtracking
+func (e *editGraph) backwardlcs(D, k int) lcs {
+	var ans lcs
+	for x := e.getBackward(D, k); x != e.ux || x-(k+e.delta) != e.uy; {
+		if ok(D-1, k-1) && x == e.getBackward(D-1, k-1) {
+			// D--, k--, x unchanged
+			D, k = D-1, k-1
+			continue
+		} else if ok(D-1, k+1) && x+1 == e.getBackward(D-1, k+1) {
+			// D--, k++, x++
+			D, k, x = D-1, k+1, x+1
+			continue
+		}
+		y := x - (k + e.delta)
+		ans = ans.append(x+e.lx, y+e.ly)
+		x++
+	}
+	return ans
+}
+
+// start at (x,y), go down the diagonal as far as possible,
+func (e *editGraph) lookBackward(k, relx int) int {
+	rely := relx - (k + e.delta) // forward k = k + e.delta
+	x, y := relx+e.lx, rely+e.ly
+	if x > 0 && y > 0 {
+		x -= e.seqs.commonSuffixLen(0, x, 0, y)
+	}
+	return x
+}
+
+// convert to rectangle, and label the result with d
+func (e *editGraph) setBackward(d, k, relx int) {
+	x := e.lookBackward(k, relx)
+	e.vb.set(d, k, x-e.lx)
+}
+
+func (e *editGraph) getBackward(d, k int) int {
+	x := e.vb.get(d, k)
+	return x
+}
+
+// -- TWOSIDED ---
+
+func twosided(e *editGraph) lcs {
+	// The termination condition could be improved, as either the forward
+	// or backward pass could succeed before Myers' Lemma applies.
+	// Aside from questions of efficiency (is the extra testing cost-effective)
+	// this is more likely to matter when e.limit is reached.
+	e.setForward(0, 0, e.lx)
+	e.setBackward(0, 0, e.ux)
+
+	// from D to D+1
+	for D := range e.limit {
+		// just finished a backwards pass, so check
+		if got, ok := e.twoDone(D, D); ok {
+			return e.twolcs(D, D, got)
+		}
+		// do a forwards pass (D to D+1)
+		e.setForward(D+1, -(D + 1), e.getForward(D, -D))
+		e.setForward(D+1, D+1, e.getForward(D, D)+1)
+		for k := -D + 1; k <= D-1; k += 2 {
+			// these are tricky and easy to get backwards
+			lookv := e.lookForward(k, e.getForward(D, k-1)+1)
+			lookh := e.lookForward(k, e.getForward(D, k+1))
+			if lookv > lookh {
+				e.setForward(D+1, k, lookv)
+			} else {
+				e.setForward(D+1, k, lookh)
+			}
+		}
+		// just did a forward pass, so check
+		if got, ok := e.twoDone(D+1, D); ok {
+			return e.twolcs(D+1, D, got)
+		}
+		// do a backward pass, D to D+1
+		e.setBackward(D+1, -(D + 1), e.getBackward(D, -D)-1)
+		e.setBackward(D+1, D+1, e.getBackward(D, D))
+		for k := -D + 1; k <= D-1; k += 2 {
+			// these are tricky and easy to get wrong
+			lookv := e.lookBackward(k, e.getBackward(D, k-1))
+			lookh := e.lookBackward(k, e.getBackward(D, k+1)-1)
+			if lookv < lookh {
+				e.setBackward(D+1, k, lookv)
+			} else {
+				e.setBackward(D+1, k, lookh)
+			}
+		}
+	}
+
+	// D too large. combine a forward and backward partial lcs
+	// first, a forward one
+	kmax := -e.limit - 1
+	diagmax := -1
+	for k := -e.limit; k <= e.limit; k += 2 {
+		x := e.getForward(e.limit, k)
+		y := x - k
+		if x+y > diagmax && x <= e.ux && y <= e.uy {
+			diagmax, kmax = x+y, k
+		}
+	}
+	if kmax < -e.limit {
+		panic(fmt.Sprintf("no forward paths when limit=%d?", e.limit))
+	}
+	lcs := e.forwardlcs(e.limit, kmax)
+	// now a backward one
+	// find the D path with minimal x+y inside the rectangle and
+	// use that to compute the lcs
+	diagmin := 1 << 25 // infinity
+	for k := -e.limit; k <= e.limit; k += 2 {
+		x := e.getBackward(e.limit, k)
+		y := x - (k + e.delta)
+		if x+y < diagmin && x >= 0 && y >= 0 {
+			diagmin, kmax = x+y, k
+		}
+	}
+	if kmax < -e.limit {
+		panic(fmt.Sprintf("no backward paths when limit=%d?", e.limit))
+	}
+	lcs = append(lcs, e.backwardlcs(e.limit, kmax)...)
+	// These may overlap (e.forwardlcs and e.backwardlcs return sorted lcs)
+	ans := lcs.fix()
+	return ans
+}
+
+// Does Myers' Lemma apply?
+func (e *editGraph) twoDone(df, db int) (int, bool) {
+	if (df+db+e.delta)%2 != 0 {
+		return 0, false // diagonals cannot overlap
+	}
+	kmin := max(-df, -db+e.delta)
+	kmax := min(df, db+e.delta)
+	for k := kmin; k <= kmax; k += 2 {
+		x := e.vf.get(df, k)
+		u := e.vb.get(db, k-e.delta)
+		if u <= x {
+			// is it worth looking at all the other k?
+			for l := k; l <= kmax; l += 2 {
+				x := e.vf.get(df, l)
+				y := x - l
+				u := e.vb.get(db, l-e.delta)
+				v := u - l
+				if x == u || u == 0 || v == 0 || y == e.uy || x == e.ux {
+					return l, true
+				}
+			}
+			return k, true
+		}
+	}
+	return 0, false
+}
+
+func (e *editGraph) twolcs(df, db, kf int) lcs {
+	// db==df || db+1==df
+	x := e.vf.get(df, kf)
+	y := x - kf
+	kb := kf - e.delta
+	u := e.vb.get(db, kb)
+	v := u - kf
+
+	// Myers proved there is a df-path from (0,0) to (u,v)
+	// and a db-path from (x,y) to (N,M).
+	// In the first case the overall path is the forward path
+	// to (u,v) followed by the backward path to (N,M).
+	// In the second case the path is the backward path to (x,y)
+	// followed by the forward path to (x,y) from (0,0).
+
+	// Look for some special cases to avoid computing either of these paths.
+	if x == u {
+		// "babaab" "cccaba"
+		// already patched together
+		lcs := e.forwardlcs(df, kf)
+		lcs = append(lcs, e.backwardlcs(db, kb)...)
+		return lcs.sort()
+	}
+
+	// is (u-1,v) or (u,v-1) labelled df-1?
+	// if so, that forward df-1-path plus a horizontal or vertical edge
+	// is the df-path to (u,v), then plus the db-path to (N,M)
+	if u > 0 && ok(df-1, u-1-v) && e.vf.get(df-1, u-1-v) == u-1 {
+		//  "aabbab" "cbcabc"
+		lcs := e.forwardlcs(df-1, u-1-v)
+		lcs = append(lcs, e.backwardlcs(db, kb)...)
+		return lcs.sort()
+	}
+	if v > 0 && ok(df-1, (u-(v-1))) && e.vf.get(df-1, u-(v-1)) == u {
+		//  "abaabb" "bcacab"
+		lcs := e.forwardlcs(df-1, u-(v-1))
+		lcs = append(lcs, e.backwardlcs(db, kb)...)
+		return lcs.sort()
+	}
+
+	// The path can't possibly contribute to the lcs because it
+	// is all horizontal or vertical edges
+	if u == 0 || v == 0 || x == e.ux || y == e.uy {
+		// "abaabb" "abaaaa"
+		if u == 0 || v == 0 {
+			return e.backwardlcs(db, kb)
+		}
+		return e.forwardlcs(df, kf)
+	}
+
+	// is (x+1,y) or (x,y+1) labelled db-1?
+	if x+1 <= e.ux && ok(db-1, x+1-y-e.delta) && e.vb.get(db-1, x+1-y-e.delta) == x+1 {
+		// "bababb" "baaabb"
+		lcs := e.backwardlcs(db-1, kb+1)
+		lcs = append(lcs, e.forwardlcs(df, kf)...)
+		return lcs.sort()
+	}
+	if y+1 <= e.uy && ok(db-1, x-(y+1)-e.delta) && e.vb.get(db-1, x-(y+1)-e.delta) == x {
+		// "abbbaa" "cabacc"
+		lcs := e.backwardlcs(db-1, kb-1)
+		lcs = append(lcs, e.forwardlcs(df, kf)...)
+		return lcs.sort()
+	}
+
+	// need to compute another path
+	// "aabbaa" "aacaba"
+	lcs := e.backwardlcs(db, kb)
+	oldx, oldy := e.ux, e.uy
+	e.ux = u
+	e.uy = v
+	lcs = append(lcs, forward(e)...)
+	e.ux, e.uy = oldx, oldy
+	return lcs.sort()
+}

--- a/vendor/golang.org/x/tools/internal/diff/lcs/sequence.go
+++ b/vendor/golang.org/x/tools/internal/diff/lcs/sequence.go
@@ -1,0 +1,70 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package lcs
+
+// This file defines the abstract sequence over which the LCS algorithm operates.
+
+// sequences abstracts a pair of sequences, A and B.
+type sequences interface {
+	lengths() (int, int)                    // len(A), len(B)
+	commonPrefixLen(ai, aj, bi, bj int) int // len(commonPrefix(A[ai:aj], B[bi:bj]))
+	commonSuffixLen(ai, aj, bi, bj int) int // len(commonSuffix(A[ai:aj], B[bi:bj]))
+}
+
+// The explicit capacity in s[i:j:j] leads to more efficient code.
+
+type bytesSeqs struct{ a, b []byte }
+
+func (s bytesSeqs) lengths() (int, int) { return len(s.a), len(s.b) }
+func (s bytesSeqs) commonPrefixLen(ai, aj, bi, bj int) int {
+	return commonPrefixLen(s.a[ai:aj:aj], s.b[bi:bj:bj])
+}
+func (s bytesSeqs) commonSuffixLen(ai, aj, bi, bj int) int {
+	return commonSuffixLen(s.a[ai:aj:aj], s.b[bi:bj:bj])
+}
+
+type runesSeqs struct{ a, b []rune }
+
+func (s runesSeqs) lengths() (int, int) { return len(s.a), len(s.b) }
+func (s runesSeqs) commonPrefixLen(ai, aj, bi, bj int) int {
+	return commonPrefixLen(s.a[ai:aj:aj], s.b[bi:bj:bj])
+}
+func (s runesSeqs) commonSuffixLen(ai, aj, bi, bj int) int {
+	return commonSuffixLen(s.a[ai:aj:aj], s.b[bi:bj:bj])
+}
+
+type linesSeqs struct{ a, b []string }
+
+func (s linesSeqs) lengths() (int, int) { return len(s.a), len(s.b) }
+func (s linesSeqs) commonPrefixLen(ai, aj, bi, bj int) int {
+	return commonPrefixLen(s.a[ai:aj], s.b[bi:bj])
+}
+func (s linesSeqs) commonSuffixLen(ai, aj, bi, bj int) int {
+	return commonSuffixLen(s.a[ai:aj], s.b[bi:bj])
+}
+
+// TODO(adonovan): optimize these functions using ideas from:
+// - https://go.dev/cl/408116 common.go
+// - https://go.dev/cl/421435 xor_generic.go
+
+// commonPrefixLen returns the length of the common prefix of a[ai:aj] and b[bi:bj].
+func commonPrefixLen[T comparable](a, b []T) int {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+// commonSuffixLen returns the length of the common suffix of a[ai:aj] and b[bi:bj].
+func commonSuffixLen[T comparable](a, b []T) int {
+	n := min(len(a), len(b))
+	i := 0
+	for i < n && a[len(a)-1-i] == b[len(b)-1-i] {
+		i++
+	}
+	return i
+}

--- a/vendor/golang.org/x/tools/internal/diff/merge.go
+++ b/vendor/golang.org/x/tools/internal/diff/merge.go
@@ -1,0 +1,81 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package diff
+
+import (
+	"slices"
+)
+
+// Merge merges two valid, ordered lists of edits.
+// It returns zero if there was a conflict.
+//
+// If corresponding edits in x and y are identical,
+// they are coalesced in the result.
+//
+// If x and y both provide different insertions at the same point,
+// the insertions from x will be first in the result.
+//
+// TODO(adonovan): this algorithm could be improved, for example by
+// working harder to coalesce non-identical edits that share a common
+// deletion or common prefix of insertion (see the tests).
+// Survey the academic literature for insights.
+func Merge(x, y []Edit) ([]Edit, bool) {
+	// Make a defensive (premature) copy of the arrays.
+	x = slices.Clone(x)
+	y = slices.Clone(y)
+
+	var merged []Edit
+	add := func(edit Edit) {
+		merged = append(merged, edit)
+	}
+	var xi, yi int
+	for xi < len(x) && yi < len(y) {
+		px := &x[xi]
+		py := &y[yi]
+
+		if *px == *py {
+			// x and y are identical: coalesce.
+			add(*px)
+			xi++
+			yi++
+
+		} else if px.End <= py.Start {
+			// x is entirely before y,
+			// or an insertion at start of y.
+			add(*px)
+			xi++
+
+		} else if py.End <= px.Start {
+			// y is entirely before x,
+			// or an insertion at start of x.
+			add(*py)
+			yi++
+
+		} else if px.Start < py.Start {
+			// x is partly before y:
+			// split it into a deletion and an edit.
+			add(Edit{px.Start, py.Start, ""})
+			px.Start = py.Start
+
+		} else if py.Start < px.Start {
+			// y is partly before x:
+			// split it into a deletion and an edit.
+			add(Edit{py.Start, px.Start, ""})
+			py.Start = px.Start
+
+		} else {
+			// x and y are unequal non-insertions
+			// at the same point: conflict.
+			return nil, false
+		}
+	}
+	for ; xi < len(x); xi++ {
+		add(x[xi])
+	}
+	for ; yi < len(y); yi++ {
+		add(y[yi])
+	}
+	return merged, true
+}

--- a/vendor/golang.org/x/tools/internal/diff/ndiff.go
+++ b/vendor/golang.org/x/tools/internal/diff/ndiff.go
@@ -1,0 +1,118 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package diff
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+
+	"golang.org/x/tools/internal/diff/lcs"
+)
+
+// Lines computes differences between two strings. All edits are at line boundaries.
+func Lines(before, after string) []Edit {
+	beforeLines, bOffsets := splitLines(before)
+	afterLines, _ := splitLines(after)
+	diffs := lcs.DiffLines(beforeLines, afterLines)
+
+	// Convert from LCS diffs to Edits
+	res := make([]Edit, len(diffs))
+	for i, d := range diffs {
+		res[i] = Edit{
+			Start: bOffsets[d.Start],
+			End:   bOffsets[d.End],
+			New:   strings.Join(afterLines[d.ReplStart:d.ReplEnd], ""),
+		}
+	}
+	return res
+}
+
+// Strings computes the differences between two strings.
+// The resulting edits respect rune boundaries.
+func Strings(before, after string) []Edit {
+	if before == after {
+		return nil // common case
+	}
+
+	if isASCII(before) && isASCII(after) {
+		// TODO(adonovan): opt: specialize diffASCII for strings.
+		return diffASCII([]byte(before), []byte(after))
+	}
+	return diffRunes([]rune(before), []rune(after))
+}
+
+// Bytes computes the differences between two byte slices.
+// The resulting edits respect rune boundaries.
+func Bytes(before, after []byte) []Edit {
+	if bytes.Equal(before, after) {
+		return nil // common case
+	}
+
+	if isASCII(before) && isASCII(after) {
+		return diffASCII(before, after)
+	}
+	return diffRunes(runes(before), runes(after))
+}
+
+func diffASCII(before, after []byte) []Edit {
+	diffs := lcs.DiffBytes(before, after)
+
+	// Convert from LCS diffs.
+	res := make([]Edit, len(diffs))
+	for i, d := range diffs {
+		res[i] = Edit{d.Start, d.End, string(after[d.ReplStart:d.ReplEnd])}
+	}
+	return res
+}
+
+func diffRunes(before, after []rune) []Edit {
+	diffs := lcs.DiffRunes(before, after)
+
+	// The diffs returned by the lcs package use indexes
+	// into whatever slice was passed in.
+	// Convert rune offsets to byte offsets.
+	res := make([]Edit, len(diffs))
+	lastEnd := 0
+	utf8Len := 0
+	for i, d := range diffs {
+		utf8Len += runesLen(before[lastEnd:d.Start]) // text between edits
+		start := utf8Len
+		utf8Len += runesLen(before[d.Start:d.End]) // text deleted by this edit
+		res[i] = Edit{start, utf8Len, string(after[d.ReplStart:d.ReplEnd])}
+		lastEnd = d.End
+	}
+	return res
+}
+
+// runes is like []rune(string(bytes)) without the duplicate allocation.
+func runes(bytes []byte) []rune {
+	n := utf8.RuneCount(bytes)
+	runes := make([]rune, n)
+	for i := range n {
+		r, sz := utf8.DecodeRune(bytes)
+		bytes = bytes[sz:]
+		runes[i] = r
+	}
+	return runes
+}
+
+// runesLen returns the length in bytes of the UTF-8 encoding of runes.
+func runesLen(runes []rune) (len int) {
+	for _, r := range runes {
+		len += utf8.RuneLen(r)
+	}
+	return len
+}
+
+// isASCII reports whether s contains only ASCII.
+func isASCII[S string | []byte](s S) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/golang.org/x/tools/internal/diff/unified.go
+++ b/vendor/golang.org/x/tools/internal/diff/unified.go
@@ -1,0 +1,314 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package diff
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// DefaultContextLines is the number of unchanged lines of surrounding
+// context displayed by Unified. Use ToUnified to specify a different value.
+const DefaultContextLines = 3
+
+// Unified returns a unified diff of the old and new strings.
+// The old and new labels are the names of the old and new files.
+// If the strings are equal, it returns the empty string.
+func Unified(oldLabel, newLabel, old, new string) string {
+	edits := Lines(old, new)
+	unified, err := ToUnified(oldLabel, newLabel, old, edits, DefaultContextLines)
+	if err != nil {
+		// Can't happen: edits are consistent.
+		log.Fatalf("internal error in diff.Unified: %v", err)
+	}
+	return unified
+}
+
+// ToUnified applies the edits to content and returns a unified diff,
+// with contextLines lines of (unchanged) context around each diff hunk.
+// The old and new labels are the names of the content and result files.
+// It returns an error if the edits are inconsistent; see ApplyEdits.
+func ToUnified(oldLabel, newLabel, content string, edits []Edit, contextLines int) (string, error) {
+	u, err := toUnified(oldLabel, newLabel, content, edits, contextLines)
+	if err != nil {
+		return "", err
+	}
+	return u.String(), nil
+}
+
+// unified represents a set of edits as a unified diff.
+type unified struct {
+	// from is the name of the original file.
+	from string
+	// to is the name of the modified file.
+	to string
+	// hunks is the set of edit hunks needed to transform the file content.
+	hunks []*hunk
+}
+
+// Hunk represents a contiguous set of line edits to apply.
+type hunk struct {
+	// The line in the original source where the hunk starts.
+	fromLine int
+	// The line in the original source where the hunk finishes.
+	toLine int
+	// The set of line based edits to apply.
+	lines []line
+}
+
+// Line represents a single line operation to apply as part of a Hunk.
+type line struct {
+	// kind is the type of line this represents, deletion, insertion or copy.
+	kind opKind
+	// content is the content of this line.
+	// For deletion it is the line being removed, for all others it is the line
+	// to put in the output.
+	content string
+}
+
+// opKind is used to denote the type of operation a line represents.
+type opKind int
+
+const (
+	// opDelete is the operation kind for a line that is present in the input
+	// but not in the output.
+	opDelete opKind = iota
+	// opInsert is the operation kind for a line that is new in the output.
+	opInsert
+	// opEqual is the operation kind for a line that is the same in the input and
+	// output, often used to provide context around edited lines.
+	opEqual
+)
+
+// String returns a human readable representation of an OpKind. It is not
+// intended for machine processing.
+func (k opKind) String() string {
+	switch k {
+	case opDelete:
+		return "delete"
+	case opInsert:
+		return "insert"
+	case opEqual:
+		return "equal"
+	default:
+		panic("unknown operation kind")
+	}
+}
+
+// toUnified takes a file contents and a sequence of edits, and calculates
+// a unified diff that represents those edits.
+func toUnified(fromName, toName string, content string, edits []Edit, contextLines int) (unified, error) {
+	gap := contextLines * 2
+	u := unified{
+		from: fromName,
+		to:   toName,
+	}
+	if len(edits) == 0 {
+		return u, nil
+	}
+	var err error
+	edits, err = lineEdits(content, edits) // expand to whole lines
+	if err != nil {
+		return u, err
+	}
+	lines, _ := splitLines(content)
+	var h *hunk
+	last := 0
+	toLine := 0
+	for _, edit := range edits {
+		// Compute the zero-based line numbers of the edit start and end.
+		// TODO(adonovan): opt: compute incrementally, avoid O(n^2).
+		start := strings.Count(content[:edit.Start], "\n")
+		end := strings.Count(content[:edit.End], "\n")
+		if edit.End == len(content) && len(content) > 0 && content[len(content)-1] != '\n' {
+			end++ // EOF counts as an implicit newline
+		}
+
+		switch {
+		case h != nil && start == last:
+			//direct extension
+		case h != nil && start <= last+gap:
+			//within range of previous lines, add the joiners
+			addEqualLines(h, lines, last, start)
+		default:
+			//need to start a new hunk
+			if h != nil {
+				// add the edge to the previous hunk
+				addEqualLines(h, lines, last, last+contextLines)
+				u.hunks = append(u.hunks, h)
+			}
+			toLine += start - last
+			h = &hunk{
+				fromLine: start + 1,
+				toLine:   toLine + 1,
+			}
+			// add the edge to the new hunk
+			delta := addEqualLines(h, lines, start-contextLines, start)
+			h.fromLine -= delta
+			h.toLine -= delta
+		}
+		last = start
+		for i := start; i < end; i++ {
+			h.lines = append(h.lines, line{kind: opDelete, content: lines[i]})
+			last++
+		}
+		if edit.New != "" {
+			v, _ := splitLines(edit.New)
+			for _, content := range v {
+				h.lines = append(h.lines, line{kind: opInsert, content: content})
+				toLine++
+			}
+		}
+	}
+	if h != nil {
+		// add the edge to the final hunk
+		addEqualLines(h, lines, last, last+contextLines)
+		u.hunks = append(u.hunks, h)
+	}
+	return u, nil
+}
+
+// split into lines removing a final empty line,
+// and also return the offsets of the line beginnings.
+func splitLines(text string) ([]string, []int) {
+	var lines []string
+	offsets := []int{0}
+	start := 0
+	for i, r := range text {
+		if r == '\n' {
+			lines = append(lines, text[start:i+1])
+			start = i + 1
+			offsets = append(offsets, start)
+		}
+	}
+	if start < len(text) {
+		lines = append(lines, text[start:])
+		offsets = append(offsets, len(text))
+	}
+	return lines, offsets
+}
+
+func addEqualLines(h *hunk, lines []string, start, end int) int {
+	delta := 0
+	for i := start; i < end; i++ {
+		if i < 0 {
+			continue
+		}
+		if i >= len(lines) {
+			return delta
+		}
+		h.lines = append(h.lines, line{kind: opEqual, content: lines[i]})
+		delta++
+	}
+	return delta
+}
+
+// String converts a unified diff to the standard textual form for that diff.
+// The output of this function can be passed to tools like patch.
+func (u unified) String() string {
+	if len(u.hunks) == 0 {
+		return ""
+	}
+	b := new(strings.Builder)
+	fmt.Fprintf(b, "--- %s\n", u.from)
+	fmt.Fprintf(b, "+++ %s\n", u.to)
+	for _, hunk := range u.hunks {
+		fromCount, toCount := 0, 0
+		for _, l := range hunk.lines {
+			switch l.kind {
+			case opDelete:
+				fromCount++
+			case opInsert:
+				toCount++
+			default:
+				fromCount++
+				toCount++
+			}
+		}
+		fmt.Fprint(b, "@@")
+		if fromCount > 1 {
+			fmt.Fprintf(b, " -%d,%d", hunk.fromLine, fromCount)
+		} else if hunk.fromLine == 1 && fromCount == 0 {
+			// Match odd GNU diff -u behavior adding to empty file.
+			fmt.Fprintf(b, " -0,0")
+		} else {
+			fmt.Fprintf(b, " -%d", hunk.fromLine)
+		}
+		if toCount > 1 {
+			fmt.Fprintf(b, " +%d,%d", hunk.toLine, toCount)
+		} else if hunk.toLine == 1 && toCount == 0 {
+			// Match odd GNU diff -u behavior adding to empty file.
+			fmt.Fprintf(b, " +0,0")
+		} else {
+			fmt.Fprintf(b, " +%d", hunk.toLine)
+		}
+		fmt.Fprint(b, " @@\n")
+		for _, l := range hunk.lines {
+			switch l.kind {
+			case opDelete:
+				fmt.Fprintf(b, "-%s", l.content)
+			case opInsert:
+				fmt.Fprintf(b, "+%s", l.content)
+			default:
+				fmt.Fprintf(b, " %s", l.content)
+			}
+			if !strings.HasSuffix(l.content, "\n") {
+				fmt.Fprintf(b, "\n\\ No newline at end of file\n")
+			}
+		}
+	}
+	return b.String()
+}
+
+// ApplyUnified applies the unified diffs.
+func ApplyUnified(udiffs, bef string) (string, error) {
+	before := strings.Split(bef, "\n")
+	unif := strings.Split(udiffs, "\n")
+	var got []string
+	left := 0
+	// parse and apply the unified diffs
+	for _, l := range unif {
+		if len(l) == 0 {
+			continue // probably the last line (from Split)
+		}
+		switch l[0] {
+		case '@': // The @@ line
+			m := atregexp.FindStringSubmatch(l)
+			fromLine, err := strconv.Atoi(m[1])
+			if err != nil {
+				return "", fmt.Errorf("missing line number in %q", l)
+			}
+			// before is a slice, so0-based; fromLine is 1-based
+			for ; left < fromLine-1; left++ {
+				got = append(got, before[left])
+			}
+		case '+': // add this line
+			if strings.HasPrefix(l, "+++ ") {
+				continue
+			}
+			got = append(got, l[1:])
+		case '-': // delete this line
+			if strings.HasPrefix(l, "--- ") {
+				continue
+			}
+			left++
+		case ' ':
+			return "", fmt.Errorf("unexpected line %q", l)
+		default:
+			return "", fmt.Errorf("invalid unified diff: <<%s>>", udiffs)
+		}
+	}
+	// copy any remaining lines
+	for ; left < len(before); left++ {
+		got = append(got, before[left])
+	}
+	return strings.Join(got, "\n"), nil
+}
+
+// The first number in the @@ lines is the line number in the 'before' data
+var atregexp = regexp.MustCompile(`@@ -(\d+).* @@`)

--- a/vendor/golang.org/x/tools/internal/facts/facts.go
+++ b/vendor/golang.org/x/tools/internal/facts/facts.go
@@ -1,0 +1,389 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package facts defines a serializable set of analysis.Fact.
+//
+// It provides a partial implementation of the Fact-related parts of the
+// analysis.Pass interface for use in analysis drivers such as "go vet"
+// and other build systems.
+//
+// The serial format is unspecified and may change, so the same version
+// of this package must be used for reading and writing serialized facts.
+//
+// The handling of facts in the analysis system parallels the handling
+// of type information in the compiler: during compilation of package P,
+// the compiler emits an export data file that describes the type of
+// every object (named thing) defined in package P, plus every object
+// indirectly reachable from one of those objects. Thus the downstream
+// compiler of package Q need only load one export data file per direct
+// import of Q, and it will learn everything about the API of package P
+// and everything it needs to know about the API of P's dependencies.
+//
+// Similarly, analysis of package P emits a fact set containing facts
+// about all objects exported from P, plus additional facts about only
+// those objects of P's dependencies that are reachable from the API of
+// package P; the downstream analysis of Q need only load one fact set
+// per direct import of Q.
+//
+// The notion of "exportedness" that matters here is that of the
+// compiler. According to the language spec, a method pkg.T.f is
+// unexported simply because its name starts with lowercase. But the
+// compiler must nonetheless export f so that downstream compilations can
+// accurately ascertain whether pkg.T implements an interface pkg.I
+// defined as interface{f()}. Exported thus means "described in export
+// data".
+package facts
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"go/types"
+	"io"
+	"log"
+	"reflect"
+	"sort"
+	"sync"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/types/objectpath"
+)
+
+const debug = false
+
+// A Set is a set of analysis.Facts.
+//
+// Decode creates a Set of facts by reading from the imports of a given
+// package, and Encode writes out the set. Between these operation,
+// the Import and Export methods will query and update the set.
+//
+// All of Set's methods except String are safe to call concurrently.
+type Set struct {
+	pkg *types.Package
+	mu  sync.Mutex
+	m   map[key]analysis.Fact
+}
+
+type key struct {
+	pkg *types.Package
+	obj types.Object // (object facts only)
+	t   reflect.Type
+}
+
+// ImportObjectFact implements analysis.Pass.ImportObjectFact.
+func (s *Set) ImportObjectFact(obj types.Object, ptr analysis.Fact) bool {
+	if obj == nil {
+		panic("nil object")
+	}
+	key := key{pkg: obj.Pkg(), obj: obj, t: reflect.TypeOf(ptr)}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.m[key]; ok {
+		reflect.ValueOf(ptr).Elem().Set(reflect.ValueOf(v).Elem())
+		return true
+	}
+	return false
+}
+
+// ExportObjectFact implements analysis.Pass.ExportObjectFact.
+func (s *Set) ExportObjectFact(obj types.Object, fact analysis.Fact) {
+	if obj.Pkg() != s.pkg {
+		log.Panicf("in package %s: ExportObjectFact(%s, %T): can't set fact on object belonging another package",
+			s.pkg, obj, fact)
+	}
+	key := key{pkg: obj.Pkg(), obj: obj, t: reflect.TypeOf(fact)}
+	s.mu.Lock()
+	s.m[key] = fact // clobber any existing entry
+	s.mu.Unlock()
+}
+
+func (s *Set) AllObjectFacts(filter map[reflect.Type]bool) []analysis.ObjectFact {
+	var facts []analysis.ObjectFact
+	s.mu.Lock()
+	for k, v := range s.m {
+		if k.obj != nil && filter[k.t] {
+			facts = append(facts, analysis.ObjectFact{Object: k.obj, Fact: v})
+		}
+	}
+	s.mu.Unlock()
+	return facts
+}
+
+// ImportPackageFact implements analysis.Pass.ImportPackageFact.
+func (s *Set) ImportPackageFact(pkg *types.Package, ptr analysis.Fact) bool {
+	if pkg == nil {
+		panic("nil package")
+	}
+	key := key{pkg: pkg, t: reflect.TypeOf(ptr)}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.m[key]; ok {
+		reflect.ValueOf(ptr).Elem().Set(reflect.ValueOf(v).Elem())
+		return true
+	}
+	return false
+}
+
+// ExportPackageFact implements analysis.Pass.ExportPackageFact.
+func (s *Set) ExportPackageFact(fact analysis.Fact) {
+	key := key{pkg: s.pkg, t: reflect.TypeOf(fact)}
+	s.mu.Lock()
+	s.m[key] = fact // clobber any existing entry
+	s.mu.Unlock()
+}
+
+func (s *Set) AllPackageFacts(filter map[reflect.Type]bool) []analysis.PackageFact {
+	var facts []analysis.PackageFact
+	s.mu.Lock()
+	for k, v := range s.m {
+		if k.obj == nil && filter[k.t] {
+			facts = append(facts, analysis.PackageFact{Package: k.pkg, Fact: v})
+		}
+	}
+	s.mu.Unlock()
+	return facts
+}
+
+// gobFact is the Gob declaration of a serialized fact.
+type gobFact struct {
+	PkgPath string          // path of package
+	Object  objectpath.Path // optional path of object relative to package itself
+	Fact    analysis.Fact   // type and value of user-defined Fact
+}
+
+// A Decoder decodes the facts from the direct imports of the package
+// provided to NewEncoder. A single decoder may be used to decode
+// multiple fact sets (e.g. each for a different set of fact types)
+// for the same package. Each call to Decode returns an independent
+// fact set.
+type Decoder struct {
+	pkg        *types.Package
+	getPackage GetPackageFunc
+}
+
+// NewDecoder returns a fact decoder for the specified package.
+//
+// It uses a brute-force recursive approach to enumerate all objects
+// defined by dependencies of pkg, so that it can learn the set of
+// package paths that may be mentioned in the fact encoding. This does
+// not scale well; use [NewDecoderFunc] where possible.
+func NewDecoder(pkg *types.Package) *Decoder {
+	// Compute the import map for this package.
+	// See the package doc comment.
+	m := importMap(pkg.Imports())
+	getPackageFunc := func(path string) *types.Package { return m[path] }
+	return NewDecoderFunc(pkg, getPackageFunc)
+}
+
+// NewDecoderFunc returns a fact decoder for the specified package.
+//
+// It calls the getPackage function for the package path string of
+// each dependency (perhaps indirect) that it encounters in the
+// encoding. If the function returns nil, the fact is discarded.
+//
+// This function is preferred over [NewDecoder] when the client is
+// capable of efficient look-up of packages by package path.
+func NewDecoderFunc(pkg *types.Package, getPackage GetPackageFunc) *Decoder {
+	return &Decoder{
+		pkg:        pkg,
+		getPackage: getPackage,
+	}
+}
+
+// A GetPackageFunc function returns the package denoted by a package path.
+type GetPackageFunc = func(pkgPath string) *types.Package
+
+// Decode decodes all the facts relevant to the analysis of package
+// pkgPath. The read function reads serialized fact data from an external
+// source for one of pkg's direct imports, identified by package path.
+// The empty file is a valid encoding of an empty fact set.
+//
+// It is the caller's responsibility to call gob.Register on all
+// necessary fact types.
+//
+// Concurrent calls to Decode are safe, so long as the
+// [GetPackageFunc] (if any) is also concurrency-safe.
+func (d *Decoder) Decode(read func(pkgPath string) ([]byte, error)) (*Set, error) {
+	// Read facts from imported packages.
+	// Facts may describe indirectly imported packages, or their objects.
+	m := make(map[key]analysis.Fact) // one big bucket
+	for _, imp := range d.pkg.Imports() {
+		logf := func(format string, args ...any) {
+			if debug {
+				prefix := fmt.Sprintf("in %s, importing %s: ",
+					d.pkg.Path(), imp.Path())
+				log.Print(prefix, fmt.Sprintf(format, args...))
+			}
+		}
+
+		// Read the gob-encoded facts.
+		data, err := read(imp.Path())
+		if err != nil {
+			return nil, fmt.Errorf("in %s, can't import facts for package %q: %v",
+				d.pkg.Path(), imp.Path(), err)
+		}
+		if len(data) == 0 {
+			continue // no facts
+		}
+		var gobFacts []gobFact
+		if err := gob.NewDecoder(bytes.NewReader(data)).Decode(&gobFacts); err != nil {
+			return nil, fmt.Errorf("decoding facts for %q: %v", imp.Path(), err)
+		}
+		logf("decoded %d facts: %v", len(gobFacts), gobFacts)
+
+		// Parse each one into a key and a Fact.
+		for _, f := range gobFacts {
+			factPkg := d.getPackage(f.PkgPath) // possibly an indirect dependency
+			if factPkg == nil {
+				// Fact relates to a dependency that was
+				// unused in this translation unit. Skip.
+				logf("no package %q; discarding %v", f.PkgPath, f.Fact)
+				continue
+			}
+			key := key{pkg: factPkg, t: reflect.TypeOf(f.Fact)}
+			if f.Object != "" {
+				// object fact
+				obj, err := objectpath.Object(factPkg, f.Object)
+				if err != nil {
+					// (most likely due to unexported object)
+					// TODO(adonovan): audit for other possibilities.
+					logf("no object for path: %v; discarding %s", err, f.Fact)
+					continue
+				}
+				key.obj = obj
+				logf("read %T fact %s for %v", f.Fact, f.Fact, key.obj)
+			} else {
+				// package fact
+				logf("read %T fact %s for %v", f.Fact, f.Fact, factPkg)
+			}
+			m[key] = f.Fact
+		}
+	}
+
+	return &Set{pkg: d.pkg, m: m}, nil
+}
+
+// Encode encodes a set of facts to a memory buffer.
+//
+// It may fail if one of the Facts could not be gob-encoded, but this is
+// a sign of a bug in an Analyzer.
+func (s *Set) Encode() []byte {
+	encoder := new(objectpath.Encoder)
+
+	// TODO(adonovan): opt: use a more efficient encoding
+	// that avoids repeating PkgPath for each fact.
+
+	// Gather all facts, including those from imported packages.
+	var gobFacts []gobFact
+
+	s.mu.Lock()
+	for k, fact := range s.m {
+		if debug {
+			log.Printf("%v => %s\n", k, fact)
+		}
+
+		// Don't export facts that we imported from another
+		// package, unless they represent fields or methods,
+		// or package-level types.
+		// (Facts about packages, and other package-level
+		// objects, are only obtained from direct imports so
+		// they needn't be reexported.)
+		//
+		// This is analogous to the pruning done by "deep"
+		// export data for types, but not as precise because
+		// we aren't careful about which structs or methods
+		// we rexport: it should be only those referenced
+		// from the API of s.pkg.
+		// TODO(adonovan): opt: be more precise. e.g.
+		// intersect with the set of objects computed by
+		// importMap(s.pkg.Imports()).
+		// TODO(adonovan): opt: implement "shallow" facts.
+		if k.pkg != s.pkg {
+			if k.obj == nil {
+				continue // imported package fact
+			}
+			if _, isType := k.obj.(*types.TypeName); !isType &&
+				k.obj.Parent() == k.obj.Pkg().Scope() {
+				continue // imported fact about package-level non-type object
+			}
+		}
+
+		var object objectpath.Path
+		if k.obj != nil {
+			path, err := encoder.For(k.obj)
+			if err != nil {
+				if debug {
+					log.Printf("discarding fact %s about %s\n", fact, k.obj)
+				}
+				continue // object not accessible from package API; discard fact
+			}
+			object = path
+		}
+		gobFacts = append(gobFacts, gobFact{
+			PkgPath: k.pkg.Path(),
+			Object:  object,
+			Fact:    fact,
+		})
+	}
+	s.mu.Unlock()
+
+	// Sort facts by (package, object, type) for determinism.
+	sort.Slice(gobFacts, func(i, j int) bool {
+		x, y := gobFacts[i], gobFacts[j]
+		if x.PkgPath != y.PkgPath {
+			return x.PkgPath < y.PkgPath
+		}
+		if x.Object != y.Object {
+			return x.Object < y.Object
+		}
+		tx := reflect.TypeOf(x.Fact)
+		ty := reflect.TypeOf(y.Fact)
+		if tx != ty {
+			return tx.String() < ty.String()
+		}
+		return false // equal
+	})
+
+	var buf bytes.Buffer
+	if len(gobFacts) > 0 {
+		if err := gob.NewEncoder(&buf).Encode(gobFacts); err != nil {
+			// Fact encoding should never fail. Identify the culprit.
+			for _, gf := range gobFacts {
+				if err := gob.NewEncoder(io.Discard).Encode(gf); err != nil {
+					fact := gf.Fact
+					pkgpath := reflect.TypeOf(fact).Elem().PkgPath()
+					log.Panicf("internal error: gob encoding of analysis fact %s failed: %v; please report a bug against fact %T in package %q",
+						fact, err, fact, pkgpath)
+				}
+			}
+		}
+	}
+
+	if debug {
+		log.Printf("package %q: encode %d facts, %d bytes\n",
+			s.pkg.Path(), len(gobFacts), buf.Len())
+	}
+
+	return buf.Bytes()
+}
+
+// String is provided only for debugging, and must not be called
+// concurrent with any Import/Export method.
+func (s *Set) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("{")
+	for k, f := range s.m {
+		if buf.Len() > 1 {
+			buf.WriteString(", ")
+		}
+		if k.obj != nil {
+			buf.WriteString(k.obj.String())
+		} else {
+			buf.WriteString(k.pkg.Path())
+		}
+		fmt.Fprintf(&buf, ": %v", f)
+	}
+	buf.WriteString("}")
+	return buf.String()
+}

--- a/vendor/golang.org/x/tools/internal/facts/imports.go
+++ b/vendor/golang.org/x/tools/internal/facts/imports.go
@@ -1,0 +1,145 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package facts
+
+import (
+	"go/types"
+
+	"golang.org/x/tools/internal/typesinternal"
+)
+
+// importMap computes the import map for a package by traversing the
+// entire exported API each of its imports.
+//
+// This is a workaround for the fact that we cannot access the map used
+// internally by the types.Importer returned by go/importer. The entries
+// in this map are the packages and objects that may be relevant to the
+// current analysis unit.
+//
+// Packages in the map that are only indirectly imported may be
+// incomplete (!pkg.Complete()).
+//
+// This function scales very poorly with packages' transitive object
+// references, which can be more than a million for each package near
+// the top of a large project. (This was a significant contributor to
+// #60621.)
+// TODO(adonovan): opt: compute this information more efficiently
+// by obtaining it from the internals of the gcexportdata decoder.
+func importMap(imports []*types.Package) map[string]*types.Package {
+	objects := make(map[types.Object]bool)
+	typs := make(map[types.Type]bool) // Named and TypeParam
+	packages := make(map[string]*types.Package)
+
+	var addObj func(obj types.Object)
+	var addType func(T types.Type)
+
+	addObj = func(obj types.Object) {
+		if !objects[obj] {
+			objects[obj] = true
+			addType(obj.Type())
+			if pkg := obj.Pkg(); pkg != nil {
+				packages[pkg.Path()] = pkg
+			}
+		}
+	}
+
+	addType = func(T types.Type) {
+		switch T := T.(type) {
+		case *types.Basic:
+			// nop
+		case typesinternal.NamedOrAlias: // *types.{Named,Alias}
+			// Add the type arguments if this is an instance.
+			if targs := T.TypeArgs(); targs.Len() > 0 {
+				for t := range targs.Types() {
+					addType(t)
+				}
+			}
+
+			// Remove infinite expansions of *types.Named by always looking at the origin.
+			// Some named types with type parameters [that will not type check] have
+			// infinite expansions:
+			//     type N[T any] struct { F *N[N[T]] }
+			// importMap() is called on such types when Analyzer.RunDespiteErrors is true.
+			T = typesinternal.Origin(T)
+			if !typs[T] {
+				typs[T] = true
+
+				// common aspects
+				addObj(T.Obj())
+				if tparams := T.TypeParams(); tparams.Len() > 0 {
+					for tparam := range tparams.TypeParams() {
+						addType(tparam)
+					}
+				}
+
+				// variant aspects
+				switch T := T.(type) {
+				case *types.Alias:
+					addType(T.Rhs())
+				case *types.Named:
+					addType(T.Underlying())
+					for method := range T.Methods() {
+						addObj(method)
+					}
+				}
+			}
+		case *types.Pointer:
+			addType(T.Elem())
+		case *types.Slice:
+			addType(T.Elem())
+		case *types.Array:
+			addType(T.Elem())
+		case *types.Chan:
+			addType(T.Elem())
+		case *types.Map:
+			addType(T.Key())
+			addType(T.Elem())
+		case *types.Signature:
+			addType(T.Params())
+			addType(T.Results())
+			if tparams := T.TypeParams(); tparams != nil {
+				for tparam := range tparams.TypeParams() {
+					addType(tparam)
+				}
+			}
+		case *types.Struct:
+			for field := range T.Fields() {
+				addObj(field)
+			}
+		case *types.Tuple:
+			for v := range T.Variables() {
+				addObj(v)
+			}
+		case *types.Interface:
+			for method := range T.Methods() {
+				addObj(method)
+			}
+			for etyp := range T.EmbeddedTypes() {
+				addType(etyp) // walk Embedded for implicits
+			}
+		case *types.Union:
+			for term := range T.Terms() {
+				addType(term.Type())
+			}
+		case *types.TypeParam:
+			if !typs[T] {
+				typs[T] = true
+				addObj(T.Obj())
+				addType(T.Constraint())
+			}
+		}
+	}
+
+	for _, imp := range imports {
+		packages[imp.Path()] = imp
+
+		scope := imp.Scope()
+		for _, name := range scope.Names() {
+			addObj(scope.Lookup(name))
+		}
+	}
+
+	return packages
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -51,6 +51,9 @@ cloud.google.com/go/storage/experimental
 cloud.google.com/go/storage/internal
 cloud.google.com/go/storage/internal/apiv2
 cloud.google.com/go/storage/internal/apiv2/storagepb
+# dmitri.shuralyov.com/go/generated v0.0.0-20170818220700-b1254a446363
+## explicit
+dmitri.shuralyov.com/go/generated
 # github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 ## explicit; go 1.23.0
 github.com/Azure/azure-sdk-for-go/sdk/azcore
@@ -446,6 +449,10 @@ github.com/facette/natsort
 # github.com/fatih/color v1.19.0
 ## explicit; go 1.25.0
 github.com/fatih/color
+# github.com/fatih/faillint v1.15.0
+## explicit; go 1.22.0
+github.com/fatih/faillint
+github.com/fatih/faillint/faillint
 # github.com/felixge/fgprof v0.9.5
 ## explicit; go 1.14
 github.com/felixge/fgprof
@@ -1788,6 +1795,14 @@ golang.org/x/text/unicode/norm
 golang.org/x/time/rate
 # golang.org/x/tools v0.47.0
 ## explicit; go 1.25.0
+golang.org/x/tools/go/analysis
+golang.org/x/tools/go/analysis/checker
+golang.org/x/tools/go/analysis/internal
+golang.org/x/tools/go/analysis/internal/analysisflags
+golang.org/x/tools/go/analysis/internal/checker
+golang.org/x/tools/go/analysis/singlechecker
+golang.org/x/tools/go/analysis/unitchecker
+golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/go/ast/edge
 golang.org/x/tools/go/ast/inspector
 golang.org/x/tools/go/gcexportdata
@@ -1795,10 +1810,15 @@ golang.org/x/tools/go/packages
 golang.org/x/tools/go/types/objectpath
 golang.org/x/tools/go/types/typeutil
 golang.org/x/tools/internal/aliases
+golang.org/x/tools/internal/analysis/driverutil
+golang.org/x/tools/internal/astutil/free
+golang.org/x/tools/internal/diff
+golang.org/x/tools/internal/diff/lcs
 golang.org/x/tools/internal/event
 golang.org/x/tools/internal/event/core
 golang.org/x/tools/internal/event/keys
 golang.org/x/tools/internal/event/label
+golang.org/x/tools/internal/facts
 golang.org/x/tools/internal/gcimporter
 golang.org/x/tools/internal/gocommand
 golang.org/x/tools/internal/packagesinternal


### PR DESCRIPTION
**What this PR does**:

Alternative to #7815, not a supplement. Both fix the same breakage and only one should land. SungJin1212 diagnosed the problem there and the diagnosis is correct; this PR disagrees only about the mechanism. #7815 force-upgrades `golang.org/x/tools` inside a throwaway module in the Dockerfile; this declares faillint as a `tool` dependency so the version comes from our own module graph.

The problem: `go install github.com/fatih/faillint@v1.15.0` resolves faillint's own `go.mod`, so it builds against `golang.org/x/tools` v0.30.0, whose decoder stops at pkgbits V2. Go 1.27 writes V4, so faillint fails with `internal error: package "net/http" without types was imported from ...`. Go 1.24 through 1.26 all wrote V2, which is why the stale pin cost nothing for three releases. faillint has had no upstream commit since 2025-03, so its pin will never advance on its own and every future pkgbits increment breaks it again.

Declaring faillint as a `tool` dependency lets MVS pick x/tools from the main module, which already requires v0.47.0 (declares V4, and carries the corrected unified reader from CL 765504). The skew becomes structurally impossible rather than a version number someone must remember to bump in a Dockerfile whenever the Go base image moves. This is the same mechanism the Go project used for its own vendored x/tools in golang/go#49159.

x/tools is deliberately left at v0.47.0. Forcing v0.49.0 also drags x/net, x/crypto, x/text and x/mod forward, and x/net is a direct dependency that ships in the binary; lint tooling should not move it.

Cost: 364 KB of vendored source (13 x/tools packages, faillint's analyzer, and `dmitri.shuralyov.com/go/generated`). `build-image/Dockerfile` loses a step, and `make lint` calls `go tool faillint`.

**Verified on Go 1.27.0**: all 8 faillint checks pass; a control run (`-paths context`) still reports violations and exits 3, so the checks are not passing vacuously; `go build -tags "netgo slicelabels" ./...` is clean; `go mod tidy` and `go mod vendor` are idempotent, so `make mod-check` passes. Lint stays hermetic: `go tool faillint` was verified with `GOPROXY=off` against `vendor/`, so the build image still needs no module cache.

Note `Makefile` has a second instance of this bug class: `make modernize` runs `golang.org/x/tools/gopls/...@v0.22.0`, which is safe on Go 1.27 only because that pin happens to postdate the V4 decode fixes. Left alone here.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [ ] Tests updated - n/a, build tooling. The faillint suite is itself the test, and the `lint` CI job exercises it.
- [ ] Documentation added - n/a
- [ ] `CHANGELOG.md` updated - n/a, build-image and lint tooling changes carry no entry, matching #7807
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags - n/a, no new flags

### AI usage disclosure

Per §3 of `GENAI_POLICY.md`: the investigation behind this change and the text of this description were substantially AI-assisted (Claude Code). Per §1, I verified the claims myself: I confirmed the vendored x/tools v0.47.0 declares V4 and has the corrected reader, reproduced the old failure on Go 1.27 in `golang:1.27.0-trixie`, and ran the faillint suite plus the control case locally on Go 1.27.0.
