### PR TITLE
fix flaky query evictor tests

### DIFF
--- a/pkg/util/queryeviction/evictor_test.go
+++ b/pkg/util/queryeviction/evictor_test.go
@@ -16,6 +16,7 @@ import (
 	querier_stats "github.com/cortexproject/cortex/pkg/querier/stats"
 	"github.com/cortexproject/cortex/pkg/util/resource"
 	"github.com/cortexproject/cortex/pkg/util/services"
+	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
 type mockMonitor struct {
@@ -138,7 +139,10 @@ func TestCPUCheckedBeforeHeap(t *testing.T) {
 	evictor := startEvictor(t, newMockMonitor(0.95, 0.95), reg, testEvictorConfig(0.9, 0.9, 0))
 	waitEvicted(t, evicted)
 
-	assert.Equal(t, float64(1), promtest.ToFloat64(evictor.evictionsTotal.WithLabelValues(string(resource.CPU))))
+	// The eviction callback runs before the counter is incremented, so poll for it.
+	test.Poll(t, time.Second, float64(1), func() any {
+		return promtest.ToFloat64(evictor.evictionsTotal.WithLabelValues(string(resource.CPU)))
+	})
 	assert.Equal(t, float64(0), promtest.ToFloat64(evictor.evictionsTotal.WithLabelValues(string(resource.Heap))))
 }
 
@@ -207,7 +211,9 @@ func TestPrometheusMetrics_IncrementedCorrectly(t *testing.T) {
 		waitEvicted(t, evicted)
 	}
 
-	assert.Equal(t, float64(3), promtest.ToFloat64(evictor.evictionsTotal.WithLabelValues(string(resource.CPU))))
+	test.Poll(t, time.Second, float64(3), func() any {
+		return promtest.ToFloat64(evictor.evictionsTotal.WithLabelValues(string(resource.CPU)))
+	})
 }
 
 func TestNewQueryEvictor_ReturnsNilWhenDisabled(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
This PR fixes flaky query evictor tests by adding polling.

The evictor could close the `evicted` channel before incrementing `evictionsTotal`, so `waitEvicted` can return while the counter is still 0.

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
