### PR TITLE
Reduce chunk batch iterator BatchSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [ENHANCEMENT] Ruler: Adjust ruler frontend decoder to not wrap query error messages with execution prefix, this makes error responses consistent between internal and external ruler paths. #7741
 * [ENHANCEMENT] Distributor: Deduplicate metric metadata when converting PRW 2.0 requests. PRW 2.0 attaches metadata to every series, so a metric family was previously expanded into one `MetricMetadata` per series. #7760
 * [ENHANCEMENT] Update build image and Go version to 1.27.0. #7814
+* [ENHANCEMENT] Querier: Reduce merge iterator `BatchSize` from 12 to 8. #7823
 * [BUGFIX] Querier: Fix queryWithRetry and labelsWithRetry returning (nil, nil) on cancelled context by propagating ctx.Err(). #7370
 * [BUGFIX] Metrics Helper: Fix non-deterministic bucket order in merged histograms by sorting buckets after map iteration, matching Prometheus client library behavior. #7380
 * [BUGFIX] Distributor: Return HTTP 401 Unauthorized when tenant ID resolution fails in the Prometheus Remote Write 2.0 path. #7389

--- a/pkg/chunk/iterator.go
+++ b/pkg/chunk/iterator.go
@@ -28,9 +28,9 @@ type Iterator interface {
 	Err() error
 }
 
-// BatchSize is samples per batch; this was choose by benchmarking all sizes from
-// 1 to 128.
-const BatchSize = 12
+// BatchSize is samples per batch; chosen by benchmarking all sizes from
+// 1 to 128. Reduced from 12 to 8 to lower per-iterator memory.
+const BatchSize = 8
 
 // Batch is a sorted set of (timestamp, value) pairs. They are intended to be small,
 // and passed by value. Value can vary depending on the chunk value type.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
  Each `newMergeIterator` allocates `batches` and `batchesBuf` slices sized by the number of chunk partitions (typically 3 with replication factor 3). With `BatchSize=12`, each `Batch` struct is 384 bytes, giving a per-iterator cost of ~2,560 bytes. With `BatchSize=8`, each `Batch` struct is 256 bytes, reducing per-iterator cost to ~1,792 bytes (**~30% reduction**).

This matters for query engines that allocate all iterators upfront - one per series - and hold them alive for the duration of the query. At high cardinality (millions of series), the cumulative merge iterator allocation becomes the dominant heap consumer. Reducing the per-iterator footprint directly reduces heap pressure under concurrent high-cardinality queries.

## Benchmark
https://github.com/cortexproject/cortex/pull/7823#issuecomment-5517339683
Seeks (15s - 60s):    ~1.5-2% slower
Seeks (300s - 6000s): 3-9% faster 
geomean:              −1.5%

**Which issue(s) this PR fixes**:
Fixes #<issue number>

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
