### PR TITLE
Enable modernize in golangci-lint and drop the standalone target

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -38,8 +38,6 @@ jobs:
         run: make BUILD_IN_CONTAINER=false mod-check
       - name: Check Protos
         run: make BUILD_IN_CONTAINER=false check-protos
-      - name: Check Modernize
-        run: make BUILD_IN_CONTAINER=false check-modernize
 
   test:
     strategy:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
   enable:
     - depguard
     - misspell
+    - modernize
     - revive
     - sloglint
   settings:

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ GOVOLUMES=	-v $(shell pwd)/.cache:/go/cache:delegated,z \
 			-v $(shell pwd)/.pkg:/go/pkg:delegated,z \
 			-v $(shell pwd):/go/src/github.com/cortexproject/cortex:delegated,z
 
-exes $(EXES) protos $(PROTO_GOS) lint test cover shell mod-check check-protos doc modernize: build-image/$(UPTODATE)
+exes $(EXES) protos $(PROTO_GOS) lint test cover shell mod-check check-protos doc: build-image/$(UPTODATE)
 	@mkdir -p $(shell pwd)/.pkg
 	@mkdir -p $(shell pwd)/.cache
 	@echo
@@ -222,9 +222,6 @@ mod-check:
 check-protos: clean-protos protos
 	@git diff --exit-code -- $(PROTO_GOS)
 
-modernize:
-	GOTOOLCHAIN=auto go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@v0.23.0 -fix ./...
-
 # Generates the config file documentation.
 doc: clean-doc
 	go run -tags slicelabels ./tools/doc-generator ./docs/configuration/config-file-reference.template > ./docs/configuration/config-file-reference.md
@@ -282,9 +279,6 @@ clean-white-noise:
 
 check-white-noise: clean-white-noise
 	@git diff --exit-code --quiet -- '*.md' || (echo "Please remove trailing whitespaces running 'make clean-white-noise'" && false)
-
-check-modernize: modernize
-	@git diff --exit-code -- . || (echo "Please modernize running 'make modernize'" && false)
 
 web-serve:
 	cd website && hugo --config config.toml --minify -v server

--- a/integration/active_series_tracker_test.go
+++ b/integration/active_series_tracker_test.go
@@ -24,9 +24,9 @@ func TestActiveSeriesTrackerPerTenant(t *testing.T) {
 	defer s.Close()
 
 	// Write runtime config with per-tenant active series trackers.
-	runtimeConfig := map[string]interface{}{
-		"overrides": map[string]interface{}{
-			"user-1": map[string]interface{}{
+	runtimeConfig := map[string]any{
+		"overrides": map[string]any{
+			"user-1": map[string]any{
 				"active_series_trackers": []map[string]string{
 					{"name": "api_metrics", "matchers": `{__name__=~"api_.*"}`},
 					{"name": "node_metrics", "matchers": `{__name__=~"node_.*"}`},
@@ -123,9 +123,9 @@ func TestActiveSeriesTrackerPerTenant(t *testing.T) {
 	require.Equal(t, 0.0, sum[0])
 
 	// Now update runtime config: remove node_metrics tracker for user-1.
-	runtimeConfig2 := map[string]interface{}{
-		"overrides": map[string]interface{}{
-			"user-1": map[string]interface{}{
+	runtimeConfig2 := map[string]any{
+		"overrides": map[string]any{
+			"user-1": map[string]any{
 				"active_series_trackers": []map[string]string{
 					{"name": "api_metrics", "matchers": `{__name__=~"api_.*"}`},
 				},

--- a/integration/alertmanager_test.go
+++ b/integration/alertmanager_test.go
@@ -639,12 +639,7 @@ func TestAlertmanagerShardingScaling(t *testing.T) {
 
 				// If the number of instances has not yet reached the replication
 				// factor, then effective replication will be reduced.
-				var expectedReplication int
-				if len(instances) <= testCfg.replicationFactor {
-					expectedReplication = len(instances)
-				} else {
-					expectedReplication = testCfg.replicationFactor
-				}
+				expectedReplication := min(len(instances), testCfg.replicationFactor)
 
 				require.NoError(t, ams.WaitSumMetrics(
 					e2e.Equals(float64(numUsers*expectedReplication)),

--- a/integration/asserts.go
+++ b/integration/asserts.go
@@ -64,7 +64,7 @@ func assertServiceMetricsPrefixes(t *testing.T, serviceType ServiceType, service
 	blacklist := getBlacklistedMetricsPrefixesByService(serviceType)
 
 	// Ensure no metric name matches the blacklisted prefixes.
-	for _, metricLine := range strings.Split(metrics, "\n") {
+	for metricLine := range strings.SplitSeq(metrics, "\n") {
 		metricLine = strings.TrimSpace(metricLine)
 		if metricLine == "" || strings.HasPrefix(metricLine, "#") {
 			continue

--- a/integration/backward_compatibility_test.go
+++ b/integration/backward_compatibility_test.go
@@ -134,8 +134,8 @@ func TestMetadataAPIWhenDeployment(t *testing.T) {
 	metadataMetricNum := 5
 	metadataPerMetrics := 2
 	metadata := make([]prompb.MetricMetadata, 0, metadataMetricNum)
-	for i := 0; i < metadataMetricNum; i++ {
-		for j := 0; j < metadataPerMetrics; j++ {
+	for i := range metadataMetricNum {
+		for j := range metadataPerMetrics {
 			metadata = append(metadata, prompb.MetricMetadata{
 				MetricFamilyName: fmt.Sprintf("metadata_name_%d", i),
 				Help:             fmt.Sprintf("metadata_help_%d_%d", i, j),
@@ -220,7 +220,7 @@ func TestCanSupportHoltWintersFunc(t *testing.T) {
 	numSamples := 240
 	serieses := make([]prompb.TimeSeries, numSeries)
 	lbls := make([]labels.Labels, numSeries)
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		series := e2e.GenerateSeriesWithSamples("test_series", start, scrapeInterval, i*numSamples, numSamples, prompb.Label{Name: "job", Value: "test"}, prompb.Label{Name: "series", Value: strconv.Itoa(i)})
 		serieses[i] = series
 

--- a/integration/configs.go
+++ b/integration/configs.go
@@ -186,7 +186,7 @@ blocks_storage:
 	})
 )
 
-func buildConfigFromTemplate(tmpl string, data interface{}) string {
+func buildConfigFromTemplate(tmpl string, data any) string {
 	t, err := template.New("config").Parse(tmpl)
 	if err != nil {
 		panic(err)

--- a/integration/e2e/scenario_test.go
+++ b/integration/e2e/scenario_test.go
@@ -154,7 +154,7 @@ func TestStartStop(t *testing.T) {
 
 	m1 := e2edb.NewMinio(9000, bktName)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		require.NoError(t, s.Start(m1))
 		require.NoError(t, s.Stop(m1))
 	}

--- a/integration/grpc_server_test.go
+++ b/integration/grpc_server_test.go
@@ -160,7 +160,7 @@ func TestConcurrentGrpcCalls(t *testing.T) {
 				wg := sync.WaitGroup{}
 				n := 10000
 				wg.Add(n)
-				for i := 0; i < n; i++ {
+				for i := range n {
 					go func(i int) {
 						defer wg.Done()
 						ctx := context.Background()
@@ -185,7 +185,7 @@ func TestConcurrentGrpcCalls(t *testing.T) {
 				wg := sync.WaitGroup{}
 				n := 10000
 				wg.Add(n)
-				for i := 0; i < n; i++ {
+				for i := range n {
 					go func(i int) {
 						defer wg.Done()
 						stream, err := client.PushStream(ctx)
@@ -216,7 +216,7 @@ func TestConcurrentGrpcCalls(t *testing.T) {
 				wg := sync.WaitGroup{}
 				n := 10000
 				wg.Add(n)
-				for i := 0; i < n; i++ {
+				for i := range n {
 					go func(i int) {
 						defer wg.Done()
 						ctx := context.Background()
@@ -284,7 +284,7 @@ func createRequest(i int) *cortexpb.WriteRequest {
 
 func createLabels(i int) []cortexpb.LabelAdapter {
 	labels := make([]cortexpb.LabelAdapter, 0, 100)
-	for j := 0; j < 100; j++ {
+	for j := range 100 {
 		labels = append(labels, cortexpb.LabelAdapter{
 			Name:  fmt.Sprintf("test%d_%d", i, j),
 			Value: fmt.Sprintf("test%d_%d", i, j),

--- a/integration/ingester_metadata_test.go
+++ b/integration/ingester_metadata_test.go
@@ -62,8 +62,8 @@ func TestIngesterMetadata(t *testing.T) {
 	metadataMetricNum := 5
 	metadataPerMetrics := 2
 	metadata := make([]prompb.MetricMetadata, 0, metadataMetricNum)
-	for i := 0; i < metadataMetricNum; i++ {
-		for j := 0; j < metadataPerMetrics; j++ {
+	for i := range metadataMetricNum {
+		for j := range metadataPerMetrics {
 			metadata = append(metadata, prompb.MetricMetadata{
 				MetricFamilyName: fmt.Sprintf("metadata_name_%d", i),
 				Help:             fmt.Sprintf("metadata_help_%d_%d", i, j),
@@ -127,8 +127,8 @@ func TestIngesterMetadataWithTenantFederation(t *testing.T) {
 	metadataMetricNum := 5
 	metadataPerMetrics := 2
 	metadata := make([]prompb.MetricMetadata, 0, metadataMetricNum)
-	for i := 0; i < metadataMetricNum; i++ {
-		for j := 0; j < metadataPerMetrics; j++ {
+	for i := range metadataMetricNum {
+		for j := range metadataPerMetrics {
 			metadata = append(metadata, prompb.MetricMetadata{
 				MetricFamilyName: fmt.Sprintf("metadata_name_%d", i),
 				Help:             fmt.Sprintf("metadata_help_%d_%d", i, j),
@@ -139,7 +139,7 @@ func TestIngesterMetadataWithTenantFederation(t *testing.T) {
 
 	numUsers := 2
 	tenantIDs := make([]string, numUsers)
-	for u := 0; u < numUsers; u++ {
+	for u := range numUsers {
 		tenantIDs[u] = fmt.Sprintf("user-%d", u)
 		c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), querier.HTTPEndpoint(), "", "", tenantIDs[u])
 		require.NoError(t, err)

--- a/integration/ingester_stream_push_test.go
+++ b/integration/ingester_stream_push_test.go
@@ -150,7 +150,7 @@ func TestIngesterStreamPushConnectionWithMatchingSigningKey(t *testing.T) {
 	require.NoError(t, err)
 
 	// Push a few series; all should succeed because the signing key matches.
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		series, _ := generateSeries(fmt.Sprintf("test_signing_ok_%d", i), now)
 		res, err := client.Push(series)
 		require.NoError(t, err)
@@ -201,7 +201,7 @@ func TestIngesterStreamPushConnectionWithMismatchedSigningKey(t *testing.T) {
 	client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", userID)
 	require.NoError(t, err)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		series, _ := generateSeries(fmt.Sprintf("test_signing_mismatch_%d", i), now)
 		res, err := client.Push(series)
 		if err == nil {
@@ -259,7 +259,7 @@ func TestIngesterStreamPushConnectionWithError(t *testing.T) {
 	client, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", userID)
 	require.NoError(t, err)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		series, _ := generateSeries("test_limit_per_metric", now,
 			prompb.Label{
 				Name:  "cardinality",

--- a/integration/integration_memberlist_single_binary_test.go
+++ b/integration/integration_memberlist_single_binary_test.go
@@ -292,7 +292,7 @@ func TestSingleBinaryWithMemberlistScaling(t *testing.T) {
 	minCortex := 3
 	instances := make([]*e2ecortex.CortexService, 0)
 
-	for i := 0; i < maxCortex; i++ {
+	for i := range maxCortex {
 		name := fmt.Sprintf("cortex-%d", i+1)
 		join := ""
 		if i > 0 {

--- a/integration/kv_test.go
+++ b/integration/kv_test.go
@@ -28,7 +28,7 @@ func TestKVList(t *testing.T) {
 		// Create keys to list back
 		keysToCreate := []string{"key-a", "key-b", "key-c"}
 		for _, key := range keysToCreate {
-			err := client.CAS(context.Background(), key, func(in interface{}) (out interface{}, retry bool, err error) {
+			err := client.CAS(context.Background(), key, func(in any) (out any, retry bool, err error) {
 				return key, false, nil
 			})
 			require.NoError(t, err, "could not create key")
@@ -50,7 +50,7 @@ func TestKVList(t *testing.T) {
 func TestKVDelete(t *testing.T) {
 	testKVs(t, func(t *testing.T, client kv.Client, reg *prometheus.Registry) {
 		// Create a key
-		err := client.CAS(context.Background(), "key-to-delete", func(in interface{}) (out interface{}, retry bool, err error) {
+		err := client.CAS(context.Background(), "key-to-delete", func(in any) (out any, retry bool, err error) {
 			return "key-to-delete", false, nil
 		})
 		require.NoError(t, err, "object could not be created")
@@ -77,20 +77,18 @@ func TestKVWatchAndDelete(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		err := client.CAS(context.Background(), "key-before-watch", func(in interface{}) (out interface{}, retry bool, err error) {
+		err := client.CAS(context.Background(), "key-before-watch", func(in any) (out any, retry bool, err error) {
 			return "value-before-watch", false, nil
 		})
 		require.NoError(t, err)
 
 		w := &watcher{}
 		wg := &sync.WaitGroup{}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			w.watch(ctx, client)
-		}()
+		})
 
-		err = client.CAS(context.Background(), "key-to-delete", func(in interface{}) (out interface{}, retry bool, err error) {
+		err = client.CAS(context.Background(), "key-to-delete", func(in any) (out any, retry bool, err error) {
 			return "value-to-delete", false, nil
 		})
 		require.NoError(t, err, "object could not be created")
@@ -127,12 +125,10 @@ func setupEtcd(t *testing.T, scenario *e2e.Scenario, reg prometheus.Registerer, 
 	etcdKv, err := kv.NewClient(kv.Config{
 		Store:  "etcd",
 		Prefix: "keys/",
-		StoreConfig: kv.StoreConfig{
-			Etcd: etcd.Config{
-				Endpoints:   []string{etcdSvc.HTTPEndpoint()},
-				DialTimeout: time.Minute,
-				MaxRetries:  5,
-			},
+		Etcd: etcd.Config{
+			Endpoints:   []string{etcdSvc.HTTPEndpoint()},
+			DialTimeout: time.Minute,
+			MaxRetries:  5,
 		},
 	}, stringCodec{}, reg, logger)
 	require.NoError(t, err)
@@ -149,13 +145,11 @@ func setupConsul(t *testing.T, scenario *e2e.Scenario, reg prometheus.Registerer
 	consulKv, err := kv.NewClient(kv.Config{
 		Store:  "consul",
 		Prefix: "keys/",
-		StoreConfig: kv.StoreConfig{
-			Consul: consul.Config{
-				Host:              consulSvc.HTTPEndpoint(),
-				HTTPClientTimeout: time.Minute,
-				WatchKeyBurstSize: 5,
-				WatchKeyRateLimit: 1,
-			},
+		Consul: consul.Config{
+			Host:              consulSvc.HTTPEndpoint(),
+			HTTPClientTimeout: time.Minute,
+			WatchKeyBurstSize: 5,
+			WatchKeyRateLimit: 1,
 		},
 	}, stringCodec{}, reg, logger)
 	require.NoError(t, err)
@@ -219,30 +213,30 @@ func verifyClientMetricsHistogram(t *testing.T, reg *prometheus.Registry, metric
 
 type stringCodec struct{}
 
-func (c stringCodec) Decode(bb []byte) (interface{}, error) {
+func (c stringCodec) Decode(bb []byte) (any, error) {
 	if bb == nil {
 		return "<nil>", nil
 	}
 	return string(bb), nil
 }
-func (c stringCodec) Encode(v interface{}) ([]byte, error) { return []byte(v.(string)), nil }
-func (c stringCodec) CodecID() string                      { return "stringCodec" }
+func (c stringCodec) Encode(v any) ([]byte, error) { return []byte(v.(string)), nil }
+func (c stringCodec) CodecID() string              { return "stringCodec" }
 
-func (stringCodec) EncodeMultiKey(msg interface{}) (map[string][]byte, error) {
+func (stringCodec) EncodeMultiKey(msg any) (map[string][]byte, error) {
 	return nil, errors.New("String codec does not support EncodeMultiKey")
 }
 
-func (stringCodec) DecodeMultiKey(map[string][]byte) (interface{}, error) {
+func (stringCodec) DecodeMultiKey(map[string][]byte) (any, error) {
 	return nil, errors.New("String codec does not support DecodeMultiKey")
 }
 
 type watcher struct {
-	values map[string][]interface{}
+	values map[string][]any
 }
 
 func (w *watcher) watch(ctx context.Context, client kv.Client) {
-	w.values = map[string][]interface{}{}
-	client.WatchPrefix(ctx, "", func(key string, value interface{}) bool {
+	w.values = map[string][]any{}
+	client.WatchPrefix(ctx, "", func(key string, value any) bool {
 		w.values[key] = append(w.values[key], value)
 		return true
 	})

--- a/integration/parquet_querier_test.go
+++ b/integration/parquet_querier_test.go
@@ -99,7 +99,7 @@ func TestParquetFuzz(t *testing.T) {
 	start := now.Add(-time.Hour * 24)
 	end := now.Add(-time.Hour)
 
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_a", "job", "test", "series", strconv.Itoa(i%3), "status_code", statusCodes[i%5]))
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_b", "job", "test", "series", strconv.Itoa((i+1)%3), "status_code", statusCodes[(i+1)%5]))
 	}
@@ -121,7 +121,7 @@ func TestParquetFuzz(t *testing.T) {
 	require.NoError(t, s.StartAndWaitReady(cortex))
 
 	// Wait until we convert the blocks
-	cortex_testutil.Poll(t, 60*time.Second, true, func() interface{} {
+	cortex_testutil.Poll(t, 60*time.Second, true, func() any {
 		found := false
 		foundBucketIndex := false
 
@@ -144,7 +144,7 @@ func TestParquetFuzz(t *testing.T) {
 	numberOfIndexesUpdate := 0
 	lastUpdate := att.LastModified
 
-	cortex_testutil.Poll(t, 30*time.Second, 5, func() interface{} {
+	cortex_testutil.Poll(t, 30*time.Second, 5, func() any {
 		att, err := bkt.Attributes(context.Background(), "bucket-index.json.gz")
 		require.NoError(t, err)
 		if lastUpdate != att.LastModified {
@@ -283,7 +283,7 @@ func TestParquetProjectionPushdownFuzz(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait until we convert the blocks to parquet AND bucket index is updated
-	cortex_testutil.Poll(t, 300*time.Second, true, func() interface{} {
+	cortex_testutil.Poll(t, 300*time.Second, true, func() any {
 		// Check if parquet marker exists
 		markerFound := false
 		err := userBucket.Iter(context.Background(), "", func(name string) error {
@@ -316,7 +316,7 @@ func TestParquetProjectionPushdownFuzz(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for data to be queryable before running the projection hints tests
-	cortex_testutil.Poll(t, 60*time.Second, true, func() interface{} {
+	cortex_testutil.Poll(t, 60*time.Second, true, func() any {
 		labelSets, err := c.Series([]string{`{job="api-server"}`}, start, end)
 		if err != nil {
 			t.Logf("Series query failed: %v", err)
@@ -505,7 +505,7 @@ func TestParquetMultiShardQuery(t *testing.T) {
 
 			// Generate unique series so the converter produces a deterministic series count.
 			lbls := make([]labels.Labels, 0, totalSeries)
-			for i := 0; i < seriesPerMetric; i++ {
+			for i := range seriesPerMetric {
 				lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_a", "job", "test", "instance", strconv.Itoa(i)))
 				lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_b", "job", "test", "instance", strconv.Itoa(i)))
 			}
@@ -549,7 +549,7 @@ func TestParquetMultiShardQuery(t *testing.T) {
 			}
 
 			// Wait until the block is converted to parquet and the bucket index is updated.
-			cortex_testutil.Poll(t, 120*time.Second, true, func() interface{} {
+			cortex_testutil.Poll(t, 120*time.Second, true, func() any {
 				found := false
 				foundBucketIndex := false
 				err := bkt.Iter(context.Background(), "", func(name string) error {
@@ -571,7 +571,7 @@ func TestParquetMultiShardQuery(t *testing.T) {
 			require.Equal(t, expectedShards, marker.Shards, "block should be split into multiple parquet shards")
 
 			// Verify each shard's parquet files (labels + chunks) exist in object storage.
-			for shardID := 0; shardID < expectedShards; shardID++ {
+			for shardID := range expectedShards {
 				labelsFile := fmt.Sprintf("%s/%d.labels.parquet", id.String(), shardID)
 				chunksFile := fmt.Sprintf("%s/%d.chunks.parquet", id.String(), shardID)
 
@@ -585,7 +585,7 @@ func TestParquetMultiShardQuery(t *testing.T) {
 			}
 
 			// Verify the block is registered in the bucket index as a parquet block with the expected shard count.
-			cortex_testutil.Poll(t, 60*time.Second, true, func() interface{} {
+			cortex_testutil.Poll(t, 60*time.Second, true, func() any {
 				idx, err := bucketindex.ReadIndex(ctx, storage.GetBucket(), "user-1", nil, log.Logger)
 				if err != nil {
 					return false
@@ -602,7 +602,7 @@ func TestParquetMultiShardQuery(t *testing.T) {
 			require.NoError(t, err)
 
 			// Wait until all series are queryable across both shards.
-			cortex_testutil.Poll(t, 120*time.Second, true, func() interface{} {
+			cortex_testutil.Poll(t, 120*time.Second, true, func() any {
 				labelSets, err := c.Series([]string{`{job="test"}`}, start, end)
 				if err != nil {
 					return false

--- a/integration/querier_sharding_test.go
+++ b/integration/querier_sharding_test.go
@@ -147,11 +147,8 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 
 	// Run all queries concurrently to get better distribution of requests between queriers.
 	for _, concurrentQueries := range batches {
-		for i := 0; i < concurrentQueries; i++ {
-			wg.Add(1)
-
-			go func() {
-				defer wg.Done()
+		for range concurrentQueries {
+			wg.Go(func() {
 				c, err := e2ecortex.NewClient("", queryFrontend.HTTPEndpoint(), "", "", userID)
 				require.NoError(t, err)
 
@@ -159,7 +156,7 @@ func runQuerierShardingTest(t *testing.T, cfg querierShardingTestConfig) {
 				require.NoError(t, err)
 				require.Equal(t, model.ValVector, result.Type())
 				assert.Equal(t, expectedVector, result.(model.Vector))
-			}()
+			})
 		}
 
 		wg.Wait()

--- a/integration/querier_tenant_federation_test.go
+++ b/integration/querier_tenant_federation_test.go
@@ -453,7 +453,7 @@ func runQuerierTenantFederationTest_UseRegexResolver(t *testing.T, cfg querierTe
 	expectedVectors := make([]model.Vector, numUsers)
 	tenantIDs := make([]string, numUsers)
 
-	for u := 0; u < numUsers; u++ {
+	for u := range numUsers {
 		tenantIDs[u] = fmt.Sprintf("user-%d", u)
 		c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", tenantIDs[u])
 		require.NoError(t, err)
@@ -626,7 +626,7 @@ func runQuerierTenantFederationTest(t *testing.T, cfg querierTenantFederationCon
 	expectedVectors := make([]model.Vector, numUsers)
 	tenantIDs := make([]string, numUsers)
 
-	for u := 0; u < numUsers; u++ {
+	for u := range numUsers {
 		tenantIDs[u] = fmt.Sprintf("user-%d", u)
 		c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", tenantIDs[u])
 		require.NoError(t, err)

--- a/integration/query_frontend_test.go
+++ b/integration/query_frontend_test.go
@@ -327,7 +327,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 	now := time.Now()
 	expectedVectors := make([]model.Vector, numUsers)
 
-	for u := 0; u < numUsers; u++ {
+	for u := range numUsers {
 		c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", fmt.Sprintf("user-%d", u))
 		require.NoError(t, err)
 
@@ -343,7 +343,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 	wg := sync.WaitGroup{}
 	wg.Add(numUsers * numQueriesPerUser)
 
-	for u := 0; u < numUsers; u++ {
+	for u := range numUsers {
 		userID := u
 
 		c, err := e2ecortex.NewClient("", queryFrontend.HTTPEndpoint(), "", "", fmt.Sprintf("user-%d", userID))
@@ -411,7 +411,7 @@ func runQueryFrontendTest(t *testing.T, cfg queryFrontendTestConfig) {
 			require.Equal(t, apiErr.Type, v1.ErrBadData)
 		}
 
-		for q := 0; q < numQueriesPerUser; q++ {
+		for range numQueriesPerUser {
 			go func() {
 				defer wg.Done()
 
@@ -996,7 +996,7 @@ func TestQueryFrontendResponseSizeLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	startTime := time.Now().Add(-1 * time.Hour)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		ts := startTime.Add(time.Duration(i) * time.Minute)
 		longLabelValue1 := strings.Repeat("long_label_value_1_", 100)
 		longLabelValue2 := strings.Repeat("long_label_value_2_", 100)

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -117,7 +117,7 @@ func TestNativeHistogramFuzz(t *testing.T) {
 	lbls := make([]labels.Labels, 0, numSeries*2)
 	scrapeInterval := time.Minute
 	statusCodes := []string{"200", "400", "404", "500", "502"}
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_a", "job", "test", "series", strconv.Itoa(i%3), "status_code", statusCodes[i%5]))
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_b", "job", "test", "series", strconv.Itoa((i+1)%3), "status_code", statusCodes[(i+1)%5]))
 	}
@@ -218,7 +218,7 @@ func TestExperimentalPromQLFuncsWithPrometheus(t *testing.T) {
 	lbls := make([]labels.Labels, 0, numSeries*2)
 	scrapeInterval := time.Minute
 	statusCodes := []string{"200", "400", "404", "500", "502"}
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_a", "job", "test", "series", strconv.Itoa(i%3), "status_code", statusCodes[i%5]))
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_b", "job", "test", "series", strconv.Itoa((i+1)%3), "status_code", statusCodes[(i+1)%5]))
 	}
@@ -338,7 +338,7 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 	numSamples := 240
 	serieses := make([]prompb.TimeSeries, numSeries)
 	lbls := make([]labels.Labels, numSeries)
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		series := e2e.GenerateSeriesWithSamples("test_series", start, scrapeInterval, i*numSamples, numSamples, prompb.Label{Name: "job", Value: "test"}, prompb.Label{Name: "series", Value: strconv.Itoa(i)})
 		serieses[i] = series
 
@@ -381,7 +381,7 @@ func TestDisableChunkTrimmingFuzz(t *testing.T) {
 		expr  parser.Expr
 		query string
 	)
-	for i := 0; i < testRun; i++ {
+	for range testRun {
 		for {
 			expr = ps.WalkRangeQuery()
 			query = expr.Pretty(0)
@@ -521,8 +521,8 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 	ss := make([]prompb.TimeSeries, numSeries*numberOfLabelsPerSeries)
 	lbls := make([]labels.Labels, numSeries*numberOfLabelsPerSeries)
 
-	for i := 0; i < numSeries; i++ {
-		for j := 0; j < numberOfLabelsPerSeries; j++ {
+	for i := range numSeries {
+		for j := range numberOfLabelsPerSeries {
 			series := e2e.GenerateSeriesWithSamples(
 				fmt.Sprintf("test_series_%d", i),
 				start,
@@ -552,7 +552,7 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 	testRun := 300
 	queries := make([]string, 0, testRun)
 	matchers := make([]string, 0, testRun)
-	for i := 0; i < testRun; i++ {
+	for i := range testRun {
 		var expr parser.Expr
 		for {
 			expr = ps.WalkRangeQuery()
@@ -569,11 +569,11 @@ func TestExpandedPostingsCacheFuzz(t *testing.T) {
 	}
 
 	// Lets run multiples iterations and create new series every iteration
-	for k := 0; k < 5; k++ {
+	for k := range 5 {
 
 		nss := make([]prompb.TimeSeries, numSeries*numberOfLabelsPerSeries)
-		for i := 0; i < numSeries; i++ {
-			for j := 0; j < numberOfLabelsPerSeries; j++ {
+		for i := range numSeries {
+			for j := range numberOfLabelsPerSeries {
 				nss[i*numberOfLabelsPerSeries+j] = e2e.GenerateSeriesWithSamples(
 					fmt.Sprintf("test_series_%d", i),
 					start.Add(scrapeInterval*time.Duration(numSamples*j)),
@@ -770,8 +770,8 @@ func TestLazyMatchersFuzz(t *testing.T) {
 	ss := make([]prompb.TimeSeries, numSeries*numberOfLabelsPerSeries)
 	lbls := make([]labels.Labels, numSeries*numberOfLabelsPerSeries)
 
-	for i := 0; i < numSeries; i++ {
-		for j := 0; j < numberOfLabelsPerSeries; j++ {
+	for i := range numSeries {
+		for j := range numberOfLabelsPerSeries {
 			series := e2e.GenerateSeriesWithSamples(
 				fmt.Sprintf("test_series_%d", i),
 				start,
@@ -817,7 +817,7 @@ func TestLazyMatchersFuzz(t *testing.T) {
 	testRun := 300
 	queries := make([]string, 0, testRun*2)
 	matchers := make([]string, 0, testRun)
-	for i := 0; i < testRun; i++ {
+	for i := range testRun {
 		expr := ps.WalkRangeQuery()
 		if !isValidQuery(expr, true) {
 			continue
@@ -1010,7 +1010,7 @@ func TestVerticalShardingFuzz(t *testing.T) {
 	lbls := make([]labels.Labels, numSeries*2)
 	serieses := make([]prompb.TimeSeries, numSeries*2)
 	scrapeInterval := 30 * time.Second
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		series := e2e.GenerateSeriesWithSamples("test_series_a", start, scrapeInterval, i*numSamples, numSamples, prompb.Label{Name: "job", Value: "test"}, prompb.Label{Name: "series", Value: strconv.Itoa(i)})
 		serieses[i] = series
 		builder := labels.NewBuilder(labels.EmptyLabels())
@@ -1126,7 +1126,7 @@ func TestProtobufCodecFuzz(t *testing.T) {
 	lbls := make([]labels.Labels, numSeries*2)
 	serieses := make([]prompb.TimeSeries, numSeries*2)
 	scrapeInterval := 30 * time.Second
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		series := e2e.GenerateSeriesWithSamples("test_series_a", start, scrapeInterval, i*numSamples, numSamples, prompb.Label{Name: "job", Value: "test"}, prompb.Label{Name: "series", Value: strconv.Itoa(i)})
 		serieses[i] = series
 		builder := labels.NewBuilder(labels.EmptyLabels())
@@ -1193,10 +1193,10 @@ var sampleNumComparer = cmp.Comparer(func(x, y model.Value) bool {
 	mySamples := 0
 
 	if xmat && ymat {
-		for i := 0; i < len(mx); i++ {
+		for i := range mx {
 			mxSamples += len(mx[i].Values)
 		}
-		for i := 0; i < len(my); i++ {
+		for i := range my {
 			mySamples += len(my[i].Values)
 		}
 	}
@@ -1344,7 +1344,7 @@ var comparer = cmp.Comparer(func(x, y model.Value) bool {
 		sort.Sort(vx)
 		sort.Sort(vy)
 
-		for i := 0; i < len(vx); i++ {
+		for i := range vx {
 			if !compareMetrics(vx[i].Metric, vy[i].Metric) {
 				return false
 			}
@@ -1371,7 +1371,7 @@ var comparer = cmp.Comparer(func(x, y model.Value) bool {
 		// Sort matrix before comparing.
 		sort.Sort(mx)
 		sort.Sort(my)
-		for i := 0; i < len(mx); i++ {
+		for i := range mx {
 			mxs := mx[i]
 			mys := my[i]
 
@@ -1385,7 +1385,7 @@ var comparer = cmp.Comparer(func(x, y model.Value) bool {
 			if len(xps) != len(yps) {
 				return false
 			}
-			for j := 0; j < len(xps); j++ {
+			for j := range xps {
 				if xps[j].Timestamp != yps[j].Timestamp {
 					return false
 				}
@@ -1400,7 +1400,7 @@ var comparer = cmp.Comparer(func(x, y model.Value) bool {
 			if len(xhs) != len(yhs) {
 				return false
 			}
-			for j := 0; j < len(xhs); j++ {
+			for j := range xhs {
 				if xhs[j].Timestamp != yhs[j].Timestamp {
 					return false
 				}
@@ -1478,7 +1478,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzz(t *testing.T) {
 	scrapeInterval := (10 * time.Second).Milliseconds()
 	metricName := "http_requests_total"
 	statusCodes := []string{"200", "400", "404", "500", "502"}
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, metricName, "job", "test", "series", strconv.Itoa(i%200), "status_code", statusCodes[i%5]))
 	}
 	ctx := context.Background()
@@ -1545,7 +1545,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzz(t *testing.T) {
 	}
 
 	cases := make([]*testCase, 0, 1000)
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		matchers := ps.WalkSelectors()
 		matcherStrings := storepb.PromMatchersToString(matchers...)
 		minT := e2e.RandRange(rnd, startMs, endMs)
@@ -1633,7 +1633,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzzWithPrometheus(t *testing.T) 
 	scrapeInterval := (10 * time.Second).Milliseconds()
 	metricName := "http_requests_total"
 	statusCodes := []string{"200", "400", "404", "500", "502"}
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, metricName, "job", "test", "series", strconv.Itoa(i%200), "status_code", statusCodes[i%5]))
 	}
 	ctx := context.Background()
@@ -1706,7 +1706,7 @@ func TestStoreGatewayLazyExpandedPostingsSeriesFuzzWithPrometheus(t *testing.T) 
 	}
 
 	cases := make([]*testCase, 0, 1000)
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		matchers := ps.WalkSelectors()
 		matcherStrings := storepb.PromMatchersToString(matchers...)
 		minT := e2e.RandRange(rnd, startMs, endMs)
@@ -1753,7 +1753,7 @@ var labelSetsComparer = cmp.Comparer(func(x, y []model.LabelSet) bool {
 	if len(x) != len(y) {
 		return false
 	}
-	for i := 0; i < len(x); i++ {
+	for i := range x {
 		if !x[i].Equal(y[i]) {
 			return false
 		}
@@ -1832,7 +1832,7 @@ func TestBackwardCompatibilityQueryFuzz(t *testing.T) {
 	lbls := make([]labels.Labels, numSeries*2)
 	serieses := make([]prompb.TimeSeries, numSeries*2)
 	scrapeInterval := time.Minute
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		series := e2e.GenerateSeriesWithSamples("test_series_a", start, scrapeInterval, i*numSamples, numSamples, prompb.Label{Name: "job", Value: "test"}, prompb.Label{Name: "series", Value: strconv.Itoa(i)})
 		serieses[i] = series
 		builder := labels.NewBuilder(labels.EmptyLabels())
@@ -1936,7 +1936,7 @@ func TestPrometheusCompatibilityQueryFuzz(t *testing.T) {
 	lbls := make([]labels.Labels, 0, numSeries*2)
 	scrapeInterval := time.Minute
 	statusCodes := []string{"200", "400", "404", "500", "502"}
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_a", "job", "test", "series", strconv.Itoa(i%3), "status_code", statusCodes[i%5]))
 		lbls = append(lbls, labels.FromStrings(labels.MetricName, "test_series_b", "job", "test", "series", strconv.Itoa((i+1)%3), "status_code", statusCodes[(i+1)%5]))
 	}
@@ -2052,7 +2052,7 @@ func TestRW1vsRW2QueryFuzz(t *testing.T) {
 	lbls := make([]labels.Labels, numSeries*2)
 	serieses := make([]prompb.TimeSeries, numSeries*2)
 
-	for i := 0; i < numSeries; i++ {
+	for i := range numSeries {
 		series := e2e.GenerateSeriesWithSamples("test_series_a", start, scrapeInterval, i*numSamples, numSamples,
 			prompb.Label{Name: "job", Value: "test"},
 			prompb.Label{Name: "series", Value: strconv.Itoa(i)},
@@ -2184,7 +2184,7 @@ func runQueryFuzzTestCases(t *testing.T, ps *promqlsmith.PromQLSmith, c1, c2 *e2
 		expr  parser.Expr
 		query string
 	)
-	for i := 0; i < run; i++ {
+	for range run {
 		for {
 			expr = ps.WalkInstantQuery()
 			if isValidQuery(expr, skipStdAggregations) {
@@ -2205,7 +2205,7 @@ func runQueryFuzzTestCases(t *testing.T, ps *promqlsmith.PromQLSmith, c1, c2 *e2
 		})
 	}
 
-	for i := 0; i < run; i++ {
+	for range run {
 		for {
 			expr = ps.WalkRangeQuery()
 			if isValidQuery(expr, skipStdAggregations) {

--- a/integration/query_response_compression_test.go
+++ b/integration/query_response_compression_test.go
@@ -47,7 +47,7 @@ func TestQuerierResponseCompression(t *testing.T) {
 	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), "", "", "", "user-1")
 	require.NoError(t, err)
 
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		series, _ := generateSeries(
 			fmt.Sprintf("series_%d", i),
 			now,
@@ -145,7 +145,7 @@ func TestQueryFrontendResponseCompression(t *testing.T) {
 	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", "user-1")
 	require.NoError(t, err)
 
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		series, _ := generateSeries(
 			fmt.Sprintf("series_%d", i),
 			now,

--- a/integration/ruler_test.go
+++ b/integration/ruler_test.go
@@ -273,7 +273,7 @@ func TestRulerSharding(t *testing.T) {
 	// Generate multiple rule groups, with 1 rule each.
 	ruleGroups := make([]rulefmt.RuleGroup, numRulesGroups)
 	expectedNames := make([]string, numRulesGroups)
-	for i := 0; i < numRulesGroups; i++ {
+	for i := range numRulesGroups {
 		ruleName := fmt.Sprintf("test_%d", i)
 
 		expectedNames[i] = ruleName
@@ -373,7 +373,7 @@ func testRulerAPIWithSharding(t *testing.T, enableRulesBackup bool) {
 		"rule_label_2":    "val2",
 		"duplicate_label": "rule_val",
 	}
-	for i := 0; i < numRulesGroups; i++ {
+	for i := range numRulesGroups {
 		num := random.Intn(100)
 		ruleName := fmt.Sprintf("test_%d", i)
 		expectedNames[i] = ruleName
@@ -490,7 +490,7 @@ func testRulerAPIWithSharding(t *testing.T, enableRulesBackup bool) {
 			},
 			resultCheckFn: func(t assert.TestingT, ruleGroups []*ruler.RuleGroup) {
 				for _, ruleGroup := range ruleGroups {
-					rule := ruleGroup.Rules[0].(map[string]interface{})
+					rule := ruleGroup.Rules[0].(map[string]any)
 					ruleType := rule["type"]
 					assert.Equal(t, "alerting", ruleType, "Expected 'alerting' rule type but got %s", ruleType)
 				}
@@ -503,7 +503,7 @@ func testRulerAPIWithSharding(t *testing.T, enableRulesBackup bool) {
 			resultCheckFn: func(t assert.TestingT, ruleGroups []*ruler.RuleGroup) {
 				ruleNames := []string{}
 				for _, ruleGroup := range ruleGroups {
-					rule := ruleGroup.Rules[0].(map[string]interface{})
+					rule := ruleGroup.Rules[0].(map[string]any)
 					ruleName := rule["name"]
 					ruleNames = append(ruleNames, ruleName.(string))
 
@@ -519,9 +519,9 @@ func testRulerAPIWithSharding(t *testing.T, enableRulesBackup bool) {
 				alertsCount := 0
 				for _, ruleGroup := range ruleGroups {
 					for _, rule := range ruleGroup.Rules {
-						r := rule.(map[string]interface{})
+						r := rule.(map[string]any)
 						if v, OK := r["alerts"]; OK {
-							alerts := v.([]interface{})
+							alerts := v.([]any)
 							alertsCount = alertsCount + len(alerts)
 						}
 					}
@@ -537,9 +537,9 @@ func testRulerAPIWithSharding(t *testing.T, enableRulesBackup bool) {
 				alertsCount := 0
 				for _, ruleGroup := range ruleGroups {
 					for _, rule := range ruleGroup.Rules {
-						r := rule.(map[string]interface{})
+						r := rule.(map[string]any)
 						if v, OK := r["alerts"]; OK {
-							alerts := v.([]interface{})
+							alerts := v.([]any)
 							alertsCount = alertsCount + len(alerts)
 						}
 					}
@@ -553,7 +553,7 @@ func testRulerAPIWithSharding(t *testing.T, enableRulesBackup bool) {
 			},
 			resultCheckFn: func(t assert.TestingT, ruleGroups []*ruler.RuleGroup) {
 				for _, ruleGroup := range ruleGroups {
-					rule := ruleGroup.Rules[0].(map[string]interface{})
+					rule := ruleGroup.Rules[0].(map[string]any)
 					ruleType := rule["type"]
 					assert.Equal(t, "alerting", ruleType, "Expected 'alerting' rule type but got %s", ruleType)
 					responseJson, err := json.Marshal(rule)
@@ -609,7 +609,7 @@ func testRulesPaginationAPIWithSharding(t *testing.T, enableRulesBackup bool) {
 	expectedNames := make([]string, numRulesGroups)
 	alertCount := 0
 	evalInterval, _ := model.ParseDuration("1s")
-	for i := 0; i < numRulesGroups; i++ {
+	for i := range numRulesGroups {
 		num := random.Intn(100)
 		ruleName := fmt.Sprintf("test_%d", i)
 
@@ -775,7 +775,7 @@ func TestRulesPaginationAPIWithShardingAndNextToken(t *testing.T) {
 	expectedNames := make([]string, numRulesGroups)
 	alertCount := 0
 	evalInterval, _ := model.ParseDuration("1s")
-	for i := 0; i < numRulesGroups; i++ {
+	for i := range numRulesGroups {
 		num := random.Intn(100)
 		ruleName := fmt.Sprintf("test_%d", i)
 
@@ -1158,7 +1158,7 @@ func TestRulerMetricsForInvalidQueries(t *testing.T) {
 	require.NoError(t, err)
 
 	// Push some series to Cortex -- enough so that we can hit some limits.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		series, _ := generateSeries("metric", time.Now(), prompb.Label{Name: "foo", Value: fmt.Sprintf("%d", i)})
 
 		res, err := c.Push(series)
@@ -1476,7 +1476,7 @@ func TestRulerHAEvaluation(t *testing.T) {
 	ruleGroups := make([]rulefmt.RuleGroup, numRulesGroups)
 	expectedNames := make([]string, numRulesGroups)
 	evalInterval, _ := model.ParseDuration("2s")
-	for i := 0; i < numRulesGroups; i++ {
+	for i := range numRulesGroups {
 		num := random.Intn(10)
 		ruleName := fmt.Sprintf("test_%d", i)
 
@@ -1810,7 +1810,7 @@ func TestRulerEvalWithQueryFrontend(t *testing.T) {
 	}
 }
 
-func parseAlertFromRule(t *testing.T, rules interface{}) *alertingRule {
+func parseAlertFromRule(t *testing.T, rules any) *alertingRule {
 	responseJson, err := json.Marshal(rules)
 	require.NoError(t, err)
 

--- a/integration/scrape_native_histogram_metrics_test.go
+++ b/integration/scrape_native_histogram_metrics_test.go
@@ -93,7 +93,7 @@ func setupCortexWithNativeHistograms(t *testing.T) (*e2e.Scenario, *e2ecortex.Co
 	require.NoError(t, err)
 
 	baseTime := time.Now()
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		series := []prompb.TimeSeries{{
 			Labels: []prompb.Label{
 				{Name: "__name__", Value: "test_metric"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Before submitting:

1. Read our CONTRIBUTING.md guide
2. Rebase your PR if it gets out of sync with master
-->

**What this PR does**:
Enables the `modernize` linter in `.golangci.yml` and removes the standalone `make modernize` / `make check-modernize` targets along with the `Check Modernize` CI step.

**Which issue(s) this PR fixes**:
Fixes #7818

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
