### PR TITLE
Fix flaky compactor tests: ignore user index update loop errors

### DIFF
--- a/pkg/compactor/compactor_test.go
+++ b/pkg/compactor/compactor_test.go
@@ -1522,6 +1522,12 @@ func removeIgnoredLogs(input []string) []string {
 	ignoredLogStringsRegexList := []*regexp.Regexp{
 		regexp.MustCompile(`^level=(info|debug|warn) component=cleaner .+$`),
 		regexp.MustCompile(`^level=info component=compactor msg="set state" .+$`),
+		// The user index update loop ticks every UsersScanner.UpdateInterval (100ms in tests) and
+		// logs these whenever it runs while the ring has no healthy instance, which happens before
+		// the lifecycler is ACTIVE and again once it starts LEAVING. Both carry a variable err=
+		// payload, so they can't be matched exactly like the other lines this loop emits.
+		regexp.MustCompile(`^level=error component=compactor msg="failed to check if compactor owns updating user index" err=.+$`),
+		regexp.MustCompile(`^level=error component=compactor msg="failed to update user index" err=.+$`),
 	}
 
 	out := make([]string, 0, len(input))
@@ -1556,6 +1562,27 @@ main:
 	}
 
 	return out
+}
+
+func TestRemoveIgnoredLogs_UserIndexUpdateLoop(t *testing.T) {
+	t.Parallel()
+
+	// userIndexUpdateLoop runs in the background of every sharding-enabled compactor test and ticks
+	// every UsersScanner.UpdateInterval (100ms in tests), so any line it can emit must be ignored.
+	// Otherwise it non-deterministically leaks into the tests that assert the exact log output.
+	ignored := []string{
+		`level=error component=compactor msg="failed to check if compactor owns updating user index" err="at least 1 live replicas required, could only find 0 - unhealthy instances: 1.2.3.4:0"`,
+		`level=error component=compactor msg="failed to update user index" err="mocked error"`,
+		`level=error component=compactor msg="context timeout, exit user index update loop" err="context canceled"`,
+		`level=info component=compactor msg="successfully updated user index" duration_ms=1`,
+	}
+	assert.Empty(t, removeIgnoredLogs(ignored))
+
+	// Unrelated compactor errors must still come through.
+	kept := []string{
+		`level=error component=compactor msg="failed to compact user blocks" user=user-1 err="mocked error"`,
+	}
+	assert.Equal(t, kept, removeIgnoredLogs(kept))
 }
 
 func prepareConfig() Config {


### PR DESCRIPTION
**What this PR does**:

Fixes a flake in `pkg/compactor` where background log output non-deterministically breaks the tests
that assert the compactor's complete log set.

`userIndexUpdateLoop` runs in the background of every sharding-enabled compactor test and ticks every
`UsersScanner.UpdateInterval`, which `prepare()` sets to `100 * time.Millisecond`. Each tick calls
`ownUser(userID, true)`, which consults the ring, so any tick that lands before the lifecycler is
ACTIVE — or after it starts LEAVING at shutdown — logs:

```
level=error component=compactor msg="failed to check if compactor owns updating user index" err="at least 1 live replicas required, could only find 0 - unhealthy instances: 1.2.3.4:0"
```

The 7 assertions in `compactor_test.go` and 7 in `compactor_paritioning_test.go` that compare the full
log output with `ElementsMatch` then fail with `elements differ`, depending purely on how many ticks
fell inside the test window.

`removeIgnoredLogs` already suppresses the other two lines this loop can emit
(`successfully updated user index`, `context timeout, exit user index update loop`), but not these
two. Both carry a variable `err=` payload, so they need a regex rather than an exact map entry —
likely why they were missed when the others were added.

This is a test-synchronisation bug, not a product bug. The errors are legitimate signal in
production, so the fix is in the test helper rather than the loop.

**Which issue(s) this PR fixes**:
Fixes #7826

**How this was verified**:

The flake is timing dependent and does not reproduce locally, so this PR adds
`TestRemoveIgnoredLogs_UserIndexUpdateLoop` to cover the helper directly. I confirmed it fails
without the fix:

```
--- FAIL: TestRemoveIgnoredLogs_UserIndexUpdateLoop (0.00s)
    Error: Should be empty, but was [level=error component=compactor msg="failed to check if
    compactor owns updating user index" err="at least 1 live replicas required, could only find 0 -
    unhealthy instances: 1.2.3.4:0" level=error component=compactor msg="failed to update user index"
    err="mocked error"]
```

and passes with it. The full package also passes under the CI configuration:

```
$ go test -race -tags "netgo slicelabels" -count=1 ./pkg/compactor/...
ok  	github.com/cortexproject/cortex/pkg/compactor	115.057s
```

**Notes**:

- Also ignores `failed to update user index` from the same loop. Not yet observed in CI, but it has
  identical exposure.
- Not covered by #7794 / #7796, which fixed a different mechanism in this package (short `Poll`
  budgets, failing as `expected 1, got 0`). This one is an assertion-content race failing as
  `elements differ`.
- No `CHANGELOG.md` entry: test-only change with no user-facing impact, consistent with #7796.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags
