### PR TITLE
Fix CIDRSliceCSV appending to the previous value instead of replacing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 * [BUGFIX] Alertmanager: Tighten per-tenant config validation to reject additional file-based settings. #7767
 * [BUGFIX] Querier: Fix panic (`index out of range [-1]`) in the active request tracker when truncating a `match[]`/`query` value made entirely of invalid UTF-8 continuation bytes. The backwards scan for a rune boundary now stops at index 0 instead of underflowing. #7743
 * [BUGFIX] Config: Fix CSV-list flags/YAML fields (e.g. `-compactor.enabled-tenants`) treating an explicitly empty string as a one-element list containing an empty tenant name instead of an empty list. #7714
+* [BUGFIX] Alertmanager: Fix per-tenant `alertmanager_receivers_firewall_block_cidr_networks` overrides being appended to the global default list instead of replacing it, so CIDRs a tenant left out of its list stayed blocked. #7831
 
 ## 1.21.1 2026-06-04
 

--- a/pkg/util/flagext/cidr.go
+++ b/pkg/util/flagext/cidr.go
@@ -46,17 +46,19 @@ func (c CIDRSliceCSV) String() string {
 
 // Set implements flag.Value
 func (c *CIDRSliceCSV) Set(s string) error {
-	parts := strings.SplitSeq(s, ",")
+	// Build into a fresh slice so the value replaces the previous one and a bad entry leaves it untouched.
+	var values CIDRSliceCSV
 
-	for part := range parts {
+	for part := range strings.SplitSeq(s, ",") {
 		cidr := &CIDR{}
 		if err := cidr.Set(part); err != nil {
 			return errors.Wrapf(err, "cidr: %s", part)
 		}
 
-		*c = append(*c, *cidr)
+		values = append(values, *cidr)
 	}
 
+	*c = values
 	return nil
 }
 

--- a/pkg/util/flagext/cidr_test.go
+++ b/pkg/util/flagext/cidr_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -48,4 +49,21 @@ func Test_CIDRSliceCSV_YamlMarshalling(t *testing.T) {
 			assert.Equal(t, tc.input, string(out))
 		})
 	}
+}
+
+func Test_CIDRSliceCSV_SetReplacesPreviousValue(t *testing.T) {
+	c := CIDRSliceCSV{}
+	require.NoError(t, c.Set("10.0.0.0/8,192.168.0.0/16"))
+	require.NoError(t, c.Set("172.16.0.0/12"))
+
+	assert.Equal(t, "172.16.0.0/12", c.String())
+}
+
+func Test_CIDRSliceCSV_SetDoesNotMutateOnError(t *testing.T) {
+	c := CIDRSliceCSV{}
+	require.NoError(t, c.Set("10.0.0.0/8"))
+
+	// The first entry parses, the second one doesn't: the value must be left untouched.
+	require.Error(t, c.Set("192.168.0.0/16,not-a-cidr"))
+	assert.Equal(t, "10.0.0.0/8", c.String())
 }

--- a/pkg/util/validation/limits_test.go
+++ b/pkg/util/validation/limits_test.go
@@ -1278,3 +1278,25 @@ func TestQueryLimits_TenantOverridesValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestAlertmanagerReceiversBlockCIDRNetworksPerTenantOverrideReplacesDefault(t *testing.T) {
+	defaults := Limits{}
+	require.NoError(t, defaults.AlertmanagerReceiversBlockCIDRNetworks.Set("10.0.0.0/8,192.168.0.0/16"))
+	SetDefaultLimitsForYAMLUnmarshalling(defaults)
+	t.Cleanup(func() { SetDefaultLimitsForYAMLUnmarshalling(Limits{}) })
+
+	tenantLimits := map[string]*Limits{}
+	require.NoError(t, yaml.Unmarshal([]byte(`
+user1:
+  alertmanager_receivers_firewall_block_cidr_networks: 172.16.0.0/12
+`), &tenantLimits))
+
+	ov := NewOverrides(defaults, newMockTenantLimits(tenantLimits))
+
+	blocked := []string{}
+	for _, c := range ov.AlertmanagerReceiversBlockCIDRNetworks("user1") {
+		blocked = append(blocked, c.String())
+	}
+
+	assert.Equal(t, []string{"172.16.0.0/12"}, blocked)
+}


### PR DESCRIPTION
**What this PR does**:

`CIDRSliceCSV.Set` (`pkg/util/flagext/cidr.go:48`) did `*c = append(*c, *cidr)`, accumulating onto whatever the value already held instead of replacing it.

That matters because `Limits.UnmarshalYAML` (`pkg/util/validation/limits.go:489`) sets the value to the defaults and then unmarshals the tenant's YAML on top — its own comment states the invariant: *"We want to set l to the defaults and then overwrite it with the input."* For `alertmanager_receivers_firewall_block_cidr_networks` the override was appended instead, so a tenant got **operator defaults plus its own list**, and CIDRs it removed from the list stayed blocked.

Measured through `Overrides.AlertmanagerReceiversBlockCIDRNetworks` (`limits.go:1123`), the value the Alertmanager receiver firewall dialer reads at `pkg/alertmanager/alertmanager.go:668`:

```
defaults:  10.0.0.0/8, 192.168.0.0/16
tenant YAML: alertmanager_receivers_firewall_block_cidr_networks: 172.16.0.0/12

before: [10.0.0.0/8 192.168.0.0/16 172.16.0.0/12]
after:  [172.16.0.0/12]
```

This fails closed — it over-blocks rather than under-blocks — so it is a config-correctness bug, not a security issue.

**The two siblings in the same package**

| implementation | behaviour on a second `Set` |
|---|---|
| `stringslicecsv.go:15` `StringSliceCSV.Set` | `*v = strings.Split(s, ",")` — replaces |
| `secretstringslicecsv.go:23` `SecretStringSliceCSV.Set` | builds `values`, then `v.values = values` — replaces |
| `cidr.go:48` `CIDRSliceCSV.Set` | appended |

The fix follows `SecretStringSliceCSV` exactly: build into a fresh slice, assign at the end. That also makes a failed entry leave the existing value untouched, which the append version did not — it kept whatever it had already parsed before the error.

**Not changed:** `Set("")` still returns `cidr: : invalid CIDR address:` and leaves the value alone, exactly as on master. #7714 gave `StringSliceCSV` an explicit empty-string case; whether `CIDRSliceCSV` should get one too is a separate question and I left it out of this change.

**Which issue(s) this PR fixes**:
No existing issue; found by reading the three CSV slice types in `pkg/util/flagext` against each other.

**Testing**

- `Test_CIDRSliceCSV_SetReplacesPreviousValue` and `Test_CIDRSliceCSV_SetDoesNotMutateOnError` in `cidr_test.go`, plus `TestAlertmanagerReceiversBlockCIDRNetworksPerTenantOverrideReplacesDefault` in `limits_test.go`, which drives the real YAML → `Overrides` path.
- All three fail on master. The consumer test fails with `expected: []string{"172.16.0.0/12"}` / `actual: []string{"10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"}`.
- Mutation-checked in both directions. Restoring the `append` brings all three failures back. Over-correcting by clearing eagerly (`*c = nil` up front) fails `SetDoesNotMutateOnError` with `actual: ""`, and committing partial values on the error path fails it with `actual: "192.168.0.0/16"` — so the atomicity side is pinned too.
- `go test -tags "netgo slicelabels" -timeout 30m -race -count 1 ./pkg/util/... ./pkg/alertmanager/...` passes.
- `golangci-lint run` reports **0 issues**, run as v2.13.1 built with go1.27.0 inside `quay.io/cortexproject/build-image:master-7bc8b2491b` so it matches the Lint job exactly. `modernize@v0.23.0` clean, `go vet` clean, `gofmt` clean.

`Test_CIDRSliceCSV_YamlMarshalling` varies one axis — entry count — and every row starts from `TestStruct{}`, so nothing covered a second `Set` on a populated value.

**Checklist**
- [x] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
- [ ] `docs/configuration/v1-guarantees.md` updated if this PR introduces experimental flags

---

Per `GENAI_POLICY.md`: AI usage disclosure — this patch was found and written with Claude Code. I have reviewed every line and can explain it without going back to the tool. All output quoted above is verbatim from running it against master and against this branch.
