### PR TITLE
Pull minio from quay.io instead of Docker Hub

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -294,6 +294,23 @@ jobs:
           name: integration-tests-${{ matrix.arch }}
       - name: Extract Integration Tests Archive
         run: tar -xzvf integration-tests-${{ matrix.arch }}.tar.gz
+      - name: Login to Docker Hub
+        # Preload Images still pulls consul, memcached, redis and postgres from Docker Hub. #7464
+        # dropped the Install Docker Client step from this job, and with it the `docker login` that
+        # script performs, so those pulls have been anonymous ever since and are exposed to the
+        # anonymous rate limit. Authenticate here, as the build job already does.
+        #
+        # The secret is empty on pull requests from forks, so skip the login there and let the pulls
+        # stay anonymous rather than failing the step outright.
+        env:
+          DOCKER_REGISTRY_USER: ${{ secrets.DOCKER_REGISTRY_USER }}
+          DOCKER_REGISTRY_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+        run: |
+          if [ -z "${DOCKER_REGISTRY_PASSWORD:-}" ]; then
+            echo "No Docker Hub credentials available (fork pull request); pulling anonymously."
+            exit 0
+          fi
+          docker login -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD"
       - name: Preload Images
         # We download docker images used by integration tests so that all images are available
         # locally and the download time doesn't account in the test execution time, which is subject

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -317,7 +317,7 @@ jobs:
             done
           }
 
-          retry docker pull minio/minio:RELEASE.2024-05-28T17-19-04Z
+          retry docker pull quay.io/minio/minio:RELEASE.2024-05-28T17-19-04Z
           retry docker pull consul:1.8.4
           retry docker pull quay.io/coreos/etcd:v3.5.29
           if [ "$TEST_TAGS" = "integration_backward_compatibility" ]; then

--- a/development/tsdb-blocks-storage-s3-gossip/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3-gossip/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 8500:8500
 
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     command: [ "server", "/data" ]
     environment:
       - MINIO_ACCESS_KEY=cortex

--- a/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3-single-binary/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 8500:8500
 
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     command: [ "server", "/data" ]
     environment:
       - MINIO_ACCESS_KEY=cortex

--- a/development/tsdb-blocks-storage-s3/docker-compose.yml
+++ b/development/tsdb-blocks-storage-s3/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 8500:8500
 
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     command: [ "server", "/data" ]
     environment:
       - MINIO_ACCESS_KEY=cortex

--- a/integration/e2e/images/images.go
+++ b/integration/e2e/images/images.go
@@ -8,7 +8,7 @@ package images
 var (
 	Memcached  = "memcached:1.6.1"
 	Redis      = "docker.io/redis:7.0.4-alpine"
-	Minio      = "minio/minio:RELEASE.2024-05-28T17-19-04Z"
+	Minio      = "quay.io/minio/minio:RELEASE.2024-05-28T17-19-04Z"
 	Consul     = "consul:1.8.4"
 	ETCD       = "quay.io/coreos/etcd:v3.5.29"
 	Prometheus = "quay.io/prometheus/prometheus:v3.9.1"


### PR DESCRIPTION
## Problem

Every `integration` leg on every PR is failing at **Preload Images**:

```
Error response from daemon: pull access denied for minio/minio, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
WARNING: 'docker pull minio/minio:RELEASE.2024-05-28T17-19-04Z' failed (attempt 1/3); retrying in 5s...
...
ERROR: 'docker pull minio/minio:RELEASE.2024-05-28T17-19-04Z' failed after 3 attempts.
##[error]Process completed with exit code 1.
```

`minio/minio` is the first Docker Hub pull in that step, so no leg gets past it — all 24 fail in about 30s. It reproduces on a PR that only touches `CHANGELOG.md` (#7836), so it is not specific to any change under test. `master` was last green at 4061a3d (2026-09-11 16:42 UTC).

## Cause

**Not a rate limit.** I first pushed a `docker login` before the preload step to rule that out. The login succeeded:

```
Login to Docker Hub    Login Succeeded
Preload Images         Error response from daemon: pull access denied for minio/minio ...
```

The pull is still denied with valid credentials, so `docker.io/minio/minio` is no longer accessible — not throttled.

## Fix

MinIO publishes the identical image to quay.io. `quay.io/minio/minio:RELEASE.2024-05-28T17-19-04Z` is public and is a manifest list with 8 children, so it covers both the amd64 and arm64 runners:

```console
$ curl -s 'https://quay.io/api/v1/repository/minio/minio/tag/?onlyActiveTags=true&filter_tag_name=like:RELEASE.2024-05-28T17-19-04Z'
RELEASE.2024-05-28T17-19-04Z  sha256:391d1d45fdbe7  manifest list  8 children
```

Commit 1 points the integration tests, the CI preload list, and the three `development/tsdb-blocks-storage-s3*` docker-compose stacks at quay.io. The tag is unchanged, so no behaviour changes. The dev stacks are broken by the same cause today.

Commit 2 keeps the `docker login`, as hardening rather than as the fix. `Preload Images` still pulls `consul`, `memcached`, `redis` and `postgres` from Docker Hub. #7464 removed the `Install Docker Client` step from this job, and that script is where the `docker login` happens, so those pulls have been anonymous ever since and are exposed to the anonymous rate limit. Fork PRs get no secrets, so the step skips the login there and leaves those pulls anonymous rather than failing.

## Why now

`v1.22.0-rc.0` is scheduled for today per [RELEASE.md](https://github.com/cortexproject/cortex/blob/master/RELEASE.md). `integration` is a required status check, so this blocks the release cut as well as every other PR.

This branch is pushed to the main repo rather than a fork so its own CI has the secrets and can exercise commit 2.
